### PR TITLE
add overloaded depositNative function to execute srcHooks

### DIFF
--- a/contracts/AoriUtils.sol
+++ b/contracts/AoriUtils.sol
@@ -430,21 +430,33 @@ library ExecutionUtils {
  */
 library HookUtils {
     /**
-     * @notice Checks if a SrcHook is defined (has a non-zero address)
-     * @param hook The SrcHook struct to check
-     * @return True if the hook has a non-zero address
+     * @notice Validates SrcHook struct fields
+     * @param hook The SrcHook to validate
+     * @param isAllowedHook Function to check hook whitelist
+     * @param isAllowedSolver Function to check solver whitelist
      */
-    function isSome(IAori.SrcHook calldata hook) internal pure returns (bool) {
-        return hook.hookAddress != address(0);
+    function validateSrcHook(
+        IAori.SrcHook calldata hook,
+        function(address) external view returns (bool) isAllowedHook,
+        function(address) external view returns (bool) isAllowedSolver
+    ) internal view {
+        require(hook.hookAddress != address(0), "Missing hook");
+        require(isAllowedHook(hook.hookAddress), "Invalid hook address");
+        require(hook.solver != address(0), "Solver required in hook");
+        require(isAllowedSolver(hook.solver), "Invalid solver in hook");
     }
 
     /**
-     * @notice Checks if a DstHook is defined (has a non-zero address)
-     * @param hook The DstHook struct to check
-     * @return True if the hook has a non-zero address
+     * @notice Validates DstHook struct fields
+     * @param hook The DstHook to validate
+     * @param isAllowedHook Function to check hook whitelist
      */
-    function isSome(IAori.DstHook calldata hook) internal pure returns (bool) {
-        return hook.hookAddress != address(0);
+    function validateDstHook(
+        IAori.DstHook calldata hook,
+        function(address) external view returns (bool) isAllowedHook
+    ) internal view {
+        require(hook.hookAddress != address(0), "Missing hook");
+        require(isAllowedHook(hook.hookAddress), "Invalid hook address");
     }
 }
 

--- a/contracts/IAori.sol
+++ b/contracts/IAori.sol
@@ -107,6 +107,8 @@ interface IAori {
 
     function depositNative(Order calldata order) external payable;
 
+    function depositNative(Order calldata order, SrcHook calldata hook) external payable;
+
     function withdraw(address token, uint256 amount) external;
 
     function cancel(bytes32 orderId) external;

--- a/contracts/IAori.sol
+++ b/contracts/IAori.sol
@@ -40,6 +40,7 @@ interface IAori {
         address preferredToken;
         uint256 minPreferedTokenAmountOut;
         bytes instructions;
+        address solver;
     }
 
     struct DstHook {

--- a/test/Mock/MockAttacker.sol
+++ b/test/Mock/MockAttacker.sol
@@ -26,7 +26,8 @@ contract ReentrantAttacker {
             hookAddress: address(this), // Use this contract as the hook
             preferredToken: address(0x1234), // Use a different token for conversion
             minPreferedTokenAmountOut: 1000, // Arbitrary minimum amount
-            instructions: abi.encodeWithSelector(this.attackHook.selector)
+            instructions: abi.encodeWithSelector(this.attackHook.selector),
+            solver: address(0) // Placeholder - will fail validation
         });
 
         // Approve tokens first

--- a/test/foundry/10_HookFailuresTest.t.sol
+++ b/test/foundry/10_HookFailuresTest.t.sol
@@ -101,7 +101,8 @@ contract HookFailuresTest is TestUtils {
             hookAddress: address(failingHook),
             preferredToken: address(outputToken), // Different from input to take the hook path
             minPreferedTokenAmountOut: 1000, // Arbitrary minimum amount since no conversion
-            instructions: abi.encodeWithSelector(FailingHook.transfer.selector)
+            instructions: abi.encodeWithSelector(FailingHook.transfer.selector),
+            solver: solver
         });
 
         // No approval for the preferred token
@@ -125,7 +126,8 @@ contract HookFailuresTest is TestUtils {
             hookAddress: address(failingHook),
             preferredToken: address(outputToken),
             minPreferedTokenAmountOut: 1000,
-            instructions: abi.encodeWithSelector(FailingHook.transfer.selector)
+            instructions: abi.encodeWithSelector(FailingHook.transfer.selector),
+            solver: solver
         });
 
         // Approve tokens

--- a/test/foundry/12_PausedTests.t.sol
+++ b/test/foundry/12_PausedTests.t.sol
@@ -94,7 +94,8 @@ contract PausedTests is TestUtils {
             hookAddress: address(0),
             preferredToken: address(inputToken),
             minPreferedTokenAmountOut: 1000, // Arbitrary minimum amount since no conversion
-            instructions: ""
+            instructions: "",
+            solver: solver
         });
 
         vm.startPrank(solver);

--- a/test/foundry/15_SecurityAndAdvancedEdgeCasesTest.t.sol
+++ b/test/foundry/15_SecurityAndAdvancedEdgeCasesTest.t.sol
@@ -371,7 +371,8 @@ contract SecurityAndAdvancedEdgeCasesTest is TestUtils {
             hookAddress: nonWhitelistedHook,
             preferredToken: address(inputToken),
             minPreferedTokenAmountOut: 1000,
-            instructions: ""
+            instructions: "",
+            solver: solver
         });
 
         vm.prank(solver);

--- a/test/foundry/16_HookWhitelistTest.t.sol
+++ b/test/foundry/16_HookWhitelistTest.t.sol
@@ -66,7 +66,8 @@ contract HookWhitelistTest is TestUtils {
             hookAddress: address(nonWhitelistedHook),
             preferredToken: address(convertedToken),
             minPreferedTokenAmountOut: 1000, // Arbitrary minimum amount for conversion
-            instructions: abi.encodeWithSelector(MockHook.handleHook.selector, address(convertedToken), order.inputAmount)
+            instructions: abi.encodeWithSelector(MockHook.handleHook.selector, address(convertedToken), order.inputAmount),
+            solver: solver
         });
 
         // The deposit should revert with "Invalid hook address"
@@ -94,7 +95,8 @@ contract HookWhitelistTest is TestUtils {
             hookAddress: address(mockHook),
             preferredToken: address(convertedToken),
             minPreferedTokenAmountOut: 1000, // Arbitrary minimum amount for conversion
-            instructions: abi.encodeWithSelector(MockHook.handleHook.selector, address(convertedToken), order.inputAmount)
+            instructions: abi.encodeWithSelector(MockHook.handleHook.selector, address(convertedToken), order.inputAmount),
+            solver: solver
         });
 
         // The deposit should succeed with the whitelisted hook
@@ -127,7 +129,8 @@ contract HookWhitelistTest is TestUtils {
             hookAddress: address(mockHook),
             preferredToken: address(convertedToken),
             minPreferedTokenAmountOut: 1000, // Arbitrary minimum amount for conversion
-            instructions: abi.encodeWithSelector(MockHook.handleHook.selector, address(convertedToken), order.inputAmount)
+            instructions: abi.encodeWithSelector(MockHook.handleHook.selector, address(convertedToken), order.inputAmount),
+            solver: solver
         });
 
         vm.prank(solver);
@@ -171,7 +174,8 @@ contract HookWhitelistTest is TestUtils {
             hookAddress: address(mockHook),
             preferredToken: address(convertedToken),
             minPreferedTokenAmountOut: 1000, // Arbitrary minimum amount for conversion
-            instructions: abi.encodeWithSelector(MockHook.handleHook.selector, address(convertedToken), order.inputAmount)
+            instructions: abi.encodeWithSelector(MockHook.handleHook.selector, address(convertedToken), order.inputAmount),
+            solver: solver
         });
 
         vm.prank(solver);
@@ -229,7 +233,8 @@ contract HookWhitelistTest is TestUtils {
             hookAddress: address(nonWhitelistedHook),
             preferredToken: address(convertedToken),
             minPreferedTokenAmountOut: 1000, // Arbitrary minimum amount for conversion
-            instructions: abi.encodeWithSelector(MockHook.handleHook.selector, address(convertedToken), order.inputAmount)
+            instructions: abi.encodeWithSelector(MockHook.handleHook.selector, address(convertedToken), order.inputAmount),
+            solver: solver
         });
 
         // This should now work since we whitelisted the hook

--- a/test/foundry/19_EdgeCases.t.sol
+++ b/test/foundry/19_EdgeCases.t.sol
@@ -164,7 +164,8 @@ contract EdgeCasesTest is TestUtils {
             hookAddress: address(mockHook),
             preferredToken: address(inputToken),
             minPreferedTokenAmountOut: 1000, // Arbitrary minimum amount for conversion
-            instructions: abi.encodeWithSelector(MockHook.handleHook.selector, address(inputToken), 1 ether)
+            instructions: abi.encodeWithSelector(MockHook.handleHook.selector, address(inputToken), 1 ether),
+            solver: solver
         });
 
         // Ensure the token will revert on transfer

--- a/test/foundry/25_HookUtilsTests.t.sol
+++ b/test/foundry/25_HookUtilsTests.t.sol
@@ -24,18 +24,16 @@ import "../../contracts/IAori.sol";
 /**
  * @title HookTestWrapper
  * @notice Test wrapper for the HookUtils library functions
+ * @dev The isSome check is now inline since it's part of validateSrcHook/validateDstHook
  */
 contract HookTestWrapper {
-    using HookUtils for IAori.SrcHook;
-    using HookUtils for IAori.DstHook;
-    
     /**
      * @notice Checks if a SrcHook is defined (has a non-zero address)
      * @param hook The SrcHook struct to check
      * @return Whether the hook has a non-zero address
      */
     function isSomeSrcHook(IAori.SrcHook calldata hook) external pure returns (bool) {
-        return hook.isSome();
+        return hook.hookAddress != address(0);
     }
     
     /**
@@ -44,7 +42,7 @@ contract HookTestWrapper {
      * @return Whether the hook has a non-zero address
      */
     function isSomeDstHook(IAori.DstHook calldata hook) external pure returns (bool) {
-        return hook.isSome();
+        return hook.hookAddress != address(0);
     }
 }
 
@@ -76,7 +74,8 @@ contract HookUtilsTest is Test {
             hookAddress: ZERO_ADDRESS,
             preferredToken: address(0),
             minPreferedTokenAmountOut: 0,
-            instructions: bytes("")
+            instructions: bytes(""),
+            solver: address(0)
         });
         
         // Act
@@ -94,7 +93,8 @@ contract HookUtilsTest is Test {
             hookAddress: TEST_ADDRESS,
             preferredToken: address(0),
             minPreferedTokenAmountOut: 0,
-            instructions: bytes("")
+            instructions: bytes(""),
+            solver: address(0)
         });
         
         // Act
@@ -166,7 +166,8 @@ contract HookUtilsTest is Test {
                 hookAddress: addresses[i],
                 preferredToken: address(0),
                 minPreferedTokenAmountOut: 0,
-                instructions: bytes("")
+                instructions: bytes(""),
+                solver: address(0)
             });
             
             bool result = wrapper.isSomeSrcHook(hook);

--- a/test/foundry/28_singleChainHookTests.t.sol
+++ b/test/foundry/28_singleChainHookTests.t.sol
@@ -136,7 +136,8 @@ contract SingleChainHookTest is TestUtils {
             hookAddress: address(testHook),
             preferredToken: address(outputToken),
             minPreferedTokenAmountOut: uint256(outputAmount),
-            instructions: hookData
+            instructions: hookData,
+            solver: solver
         });
         
         // Calculate order ID
@@ -215,7 +216,8 @@ contract SingleChainHookTest is TestUtils {
             hookAddress: address(testHook),
             preferredToken: address(outputToken),
             minPreferedTokenAmountOut: uint256(outputAmount),
-            instructions: hookData
+            instructions: hookData,
+            solver: solver
         });
         
         // Execute deposit with hook
@@ -288,7 +290,8 @@ contract SingleChainHookTest is TestUtils {
             hookAddress: address(testHook),
             preferredToken: address(outputToken), // For single-chain, this should be output token
             minPreferedTokenAmountOut: uint256(outputAmount),
-            instructions: hookData
+            instructions: hookData,
+            solver: solver
         });
         
         // Deposit with hook - this will immediately settle for single-chain swaps
@@ -345,7 +348,8 @@ contract SingleChainHookTest is TestUtils {
             hookAddress: address(mockFailingHook),
             preferredToken: address(outputToken),
             minPreferedTokenAmountOut: uint256(outputAmount),
-            instructions: hookData
+            instructions: hookData,
+            solver: solver
         });
         
         // This should revert when the hook tries to transfer tokens it doesn't have
@@ -392,7 +396,8 @@ contract SingleChainHookTest is TestUtils {
             hookAddress: address(nonWhitelistedHook),
             preferredToken: address(outputToken),
             minPreferedTokenAmountOut: uint256(outputAmount),
-            instructions: hookData
+            instructions: hookData,
+            solver: solver
         });
         
         // Should revert with "Invalid hook address"
@@ -439,7 +444,8 @@ contract SingleChainHookTest is TestUtils {
             hookAddress: address(testHook),
             preferredToken: address(outputToken),
             minPreferedTokenAmountOut: uint256(outputAmount),
-            instructions: hookData
+            instructions: hookData,
+            solver: solver
         });
         
         // Should revert with "Insufficient output from hook"

--- a/test/foundry/29_singleChainSwapTests.t.sol
+++ b/test/foundry/29_singleChainSwapTests.t.sol
@@ -641,7 +641,8 @@ contract SingleChainSwapTests is TestUtils {
             hookAddress: address(testHook),
             preferredToken: address(outputToken),
             minPreferedTokenAmountOut: OUTPUT_AMOUNT,
-            instructions: hookData
+            instructions: hookData,
+            solver: solver
         });
         
         // Record balances before operation
@@ -700,7 +701,8 @@ contract SingleChainSwapTests is TestUtils {
             hookAddress: address(testHook),
             preferredToken: address(outputToken),
             minPreferedTokenAmountOut: OUTPUT_AMOUNT,
-            instructions: hookData
+            instructions: hookData,
+            solver: solver
         });
         
         // Record balances before
@@ -746,7 +748,8 @@ contract SingleChainSwapTests is TestUtils {
             hookAddress: address(testHook),
             preferredToken: address(outputToken),
             minPreferedTokenAmountOut: OUTPUT_AMOUNT,
-            instructions: hookData
+            instructions: hookData,
+            solver: solver
         });
         
         // Record initial balance
@@ -849,7 +852,8 @@ contract SingleChainSwapTests is TestUtils {
             hookAddress: address(testHook),
             preferredToken: address(outputToken),
             minPreferedTokenAmountOut: OUTPUT_AMOUNT,
-            instructions: createHookData(address(outputToken), OUTPUT_AMOUNT)
+            instructions: createHookData(address(outputToken), OUTPUT_AMOUNT),
+            solver: solver
         });
         
         // Ensure solver has enough output tokens

--- a/test/foundry/4_Deposit.t.sol
+++ b/test/foundry/4_Deposit.t.sol
@@ -341,7 +341,8 @@ contract DepositTests is TestUtils {
             hookAddress: address(0), // Missing hook
             preferredToken: address(inputToken),
             minPreferedTokenAmountOut: 1e18,
-            instructions: ""
+            instructions: "",
+            solver: solver
         });
         
         vm.prank(solver);
@@ -362,7 +363,8 @@ contract DepositTests is TestUtils {
             hookAddress: nonWhitelistedHook,
             preferredToken: address(inputToken),
             minPreferedTokenAmountOut: 1e18,
-            instructions: ""
+            instructions: "",
+            solver: solver
         });
         
         vm.prank(userA);

--- a/test/foundry/8_DepositFail.t.sol
+++ b/test/foundry/8_DepositFail.t.sol
@@ -105,7 +105,8 @@ contract DepositFailTest is TestUtils {
     //         hookAddress: address(failingHook),
     //         preferredToken: address(outputToken), // different from order.inputToken
     //         minPreferedTokenAmountOut: minPreferedTokenAmountOut, // Arbitrary minimum amount since no conversion
-    //         instructions: abi.encodeWithSelector(FailingDepositHook.failHook.selector, address(outputToken), order.inputAmount)
+    //         instructions: abi.encodeWithSelector(FailingDepositHook.failHook.selector, address(outputToken), order.inputAmount),
+    //         solver: solver
     //     });
     //     bytes memory signature = signOrder(order);
     //     vm.prank(userA);

--- a/test/foundry/CC_ERC20ToNativeHook.t.sol
+++ b/test/foundry/CC_ERC20ToNativeHook.t.sol
@@ -196,7 +196,8 @@ contract CC_ERC20ToNativeHook is TestUtils {
                 INPUT_AMOUNT,                   // amountIn
                 address(srcHookPreferredToken),     // tokenOut
                 SRC_PREFERRED_OUTPUT            // minAmountOut
-            )
+            ),
+            solver: solverSource
         });
 
         // Approve user's input tokens to be spent by the contract

--- a/test/foundry/CC_ERC20ToNativeSrcHook.t.sol
+++ b/test/foundry/CC_ERC20ToNativeSrcHook.t.sol
@@ -163,7 +163,8 @@ contract CC_ERC20ToNativeSrcHook is TestUtils {
                 MockHook2.handleHook.selector, 
                 address(convertedToken),   // Output preferred tokens
                 HOOK_CONVERTED_AMOUNT      // Amount of preferred tokens to output
-            )
+            ),
+            solver: solverSource
         });
 
         // Solver deposits user's ERC20 tokens with source hook

--- a/test/foundry/CC_NativeHookToDirectFill.t.sol
+++ b/test/foundry/CC_NativeHookToDirectFill.t.sol
@@ -1,0 +1,498 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+/**
+ * @title End-to-End Test: Cross-Chain Native + SrcHook → Direct Fill (No DstHook)
+ * @notice Tests the complete flow:
+ *   1. Source Chain: depositNative(order, srcHook) - User deposits native ETH with srcHook
+ *   2. Source Chain: SrcHook converts ETH to preferred token (e.g., USDC)
+ *   3. Destination Chain: fill(order) - Solver fills directly with ERC20 tokens (no hook)
+ *   4. Settlement: LayerZero message unlocks preferred tokens for solver on source chain
+ *   5. Solver withdraws preferred tokens on source chain
+ * @dev Verifies balance accounting, token transfers, and cross-chain messaging
+ * 
+ * @dev To run with detailed accounting logs:
+ *   forge test --match-test testCrossChainNativeHookToDirectFillSuccess -vv
+ */
+import {Aori, IAori} from "../../contracts/Aori.sol";
+import {Origin} from "@layerzerolabs/oapp-evm/contracts/oapp/OApp.sol";
+import {TestUtils} from "./TestUtils.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {Test} from "forge-std/Test.sol";
+import {console} from "forge-std/console.sol";
+import {MockHook2} from "../Mock/MockHook2.sol";
+import "../../contracts/AoriUtils.sol";
+
+contract CC_NativeHookToDirectFill_Test is TestUtils {
+    using NativeTokenUtils for address;
+
+    // Test amounts
+    uint128 public constant INPUT_AMOUNT = 1 ether;           // Native ETH input (user deposits)
+    uint128 public constant OUTPUT_AMOUNT = 1000e18;          // ERC20 output (user receives on dest)
+    uint128 public constant HOOK_CONVERTED_AMOUNT = 1500e18;  // srcHook converts ETH to this many tokens
+    uint128 public constant MIN_PREFERRED_OUT = 1400e18;      // Minimum acceptable from hook
+
+    // Cross-chain addresses
+    address public userSource;     // User on source chain
+    address public userDest;       // User on destination chain
+    address public solverSource;   // Solver on source chain
+    address public solverDest;     // Solver on destination chain
+
+    // Private keys for signing
+    uint256 public userSourcePrivKey = 0xABCD;
+    uint256 public solverSourcePrivKey = 0xDEAD;
+    uint256 public solverDestPrivKey = 0xBEEF;
+
+    // Order details
+    IAori.Order private order;
+    MockHook2 private mockHook2;
+
+    /**
+     * @notice Helper function to format wei amount to ETH string
+     */
+    function formatETH(int256 weiAmount) internal pure returns (string memory) {
+        if (weiAmount == 0) return "0 ETH";
+        
+        bool isNegative = weiAmount < 0;
+        uint256 absAmount = uint256(isNegative ? -weiAmount : weiAmount);
+        
+        uint256 ethPart = absAmount / 1e18;
+        uint256 weiPart = absAmount % 1e18;
+        
+        string memory sign = isNegative ? "-" : "+";
+        
+        if (weiPart == 0) {
+            return string(abi.encodePacked(sign, vm.toString(ethPart), " ETH"));
+        } else {
+            uint256 decimals = weiPart / 1e12;
+            return string(abi.encodePacked(sign, vm.toString(ethPart), ".", vm.toString(decimals), " ETH"));
+        }
+    }
+
+    /**
+     * @notice Helper function to format token amount to readable string
+     */
+    function formatTokens(int256 tokenAmount) internal pure returns (string memory) {
+        if (tokenAmount == 0) return "0 tokens";
+        
+        bool isNegative = tokenAmount < 0;
+        uint256 absAmount = uint256(isNegative ? -tokenAmount : tokenAmount);
+        
+        uint256 tokenPart = absAmount / 1e18;
+        uint256 decimalPart = absAmount % 1e18;
+        
+        string memory sign = isNegative ? "-" : "+";
+        
+        if (decimalPart == 0) {
+            return string(abi.encodePacked(sign, vm.toString(tokenPart), " tokens"));
+        } else {
+            uint256 decimals = decimalPart / 1e16;
+            return string(abi.encodePacked(sign, vm.toString(tokenPart), ".", vm.toString(decimals), " tokens"));
+        }
+    }
+
+    function setUp() public override {
+        super.setUp();
+        
+        // Derive addresses from private keys
+        userSource = vm.addr(userSourcePrivKey);
+        solverSource = vm.addr(solverSourcePrivKey);
+        solverDest = vm.addr(solverDestPrivKey);
+        userDest = makeAddr("userDest");
+        
+        // Deploy MockHook2
+        mockHook2 = new MockHook2();
+        
+        // Setup native token balances for source chain
+        vm.deal(userSource, 5 ether);
+        vm.deal(solverSource, 1 ether);
+        
+        // Setup destination chain balances
+        vm.deal(userDest, 0 ether);
+        vm.deal(solverDest, 1 ether);
+        
+        // Setup contract balances
+        vm.deal(address(localAori), 0 ether);
+        vm.deal(address(remoteAori), 0 ether);
+        
+        // Give hook the preferred token to output (what srcHook converts to)
+        convertedToken.mint(address(mockHook2), 5000e18);
+        
+        // Give solver ERC20 output tokens to fill with on destination
+        outputToken.mint(solverDest, 5000e18);
+        
+        // Add MockHook2 to allowed hooks
+        localAori.addAllowedHook(address(mockHook2));
+        remoteAori.addAllowedHook(address(mockHook2));
+        
+        // Add solvers to allowed list
+        localAori.addAllowedSolver(solverSource);
+        remoteAori.addAllowedSolver(solverDest);
+    }
+
+    /**
+     * @notice Helper to create order for native input -> ERC20 output
+     */
+    function _createOrder() internal {
+        vm.chainId(localEid);
+        
+        order = createCustomOrder(
+            userSource,                      // offerer
+            userDest,                        // recipient (different chain)
+            NATIVE_TOKEN,                    // inputToken (native ETH)
+            address(outputToken),            // outputToken (ERC20)
+            INPUT_AMOUNT,                    // inputAmount
+            OUTPUT_AMOUNT,                   // outputAmount
+            block.timestamp,                 // startTime
+            block.timestamp + 1 hours,       // endTime
+            localEid,                        // srcEid
+            remoteEid                        // dstEid (cross-chain)
+        );
+    }
+
+    /**
+     * @notice Helper to create srcHook that converts native ETH to preferred token
+     */
+    function _createSrcHook() internal view returns (IAori.SrcHook memory) {
+        return IAori.SrcHook({
+            hookAddress: address(mockHook2),
+            preferredToken: address(convertedToken),   // Hook outputs this ERC20
+            minPreferedTokenAmountOut: MIN_PREFERRED_OUT,
+            instructions: abi.encodeWithSelector(
+                MockHook2.handleHook.selector,
+                address(convertedToken),       // Output converted token
+                HOOK_CONVERTED_AMOUNT          // Amount of tokens to output
+            ),
+            solver: solverSource
+        });
+    }
+
+    /**
+     * @notice Helper to deposit native with srcHook
+     */
+    function _depositNativeWithSrcHook() internal {
+        _createOrder();
+        IAori.SrcHook memory srcHook = _createSrcHook();
+
+        vm.prank(userSource);
+        localAori.depositNative{value: INPUT_AMOUNT}(order, srcHook);
+    }
+
+    /**
+     * @notice Helper to fill order directly (no hook)
+     */
+    function _fillOrderDirectly() internal {
+        vm.chainId(remoteEid);
+        vm.warp(order.startTime + 1);
+
+        // Approve output tokens
+        vm.prank(solverDest);
+        outputToken.approve(address(remoteAori), OUTPUT_AMOUNT);
+        
+        // Fill directly without hook
+        vm.prank(solverDest);
+        remoteAori.fill(order);
+    }
+
+    /**
+     * @notice Helper to settle order via LayerZero
+     */
+    function _settleOrder() internal {
+        bytes memory options = defaultOptions();
+        uint256 fee = remoteAori.quote(localEid, 0, options, false, localEid, solverDest);
+        vm.deal(solverDest, fee);
+        vm.prank(solverDest);
+        remoteAori.settle{value: fee}(localEid, solverDest, options);
+    }
+
+    /**
+     * @notice Helper to simulate LayerZero message delivery
+     */
+    function _simulateLzMessageDelivery() internal {
+        vm.chainId(localEid);
+        bytes32 guid = keccak256("mock-guid");
+        bytes memory settlementPayload = abi.encodePacked(
+            uint8(0), // message type 0 for settlement
+            solverSource, // filler address (should be source chain solver for settlement)
+            uint16(1), // fill count
+            localAori.hash(order) // order hash
+        );
+
+        vm.prank(address(endpoints[localEid]));
+        localAori.lzReceive(
+            Origin(remoteEid, bytes32(uint256(uint160(address(remoteAori)))), 1),
+            guid,
+            settlementPayload,
+            address(0),
+            bytes("")
+        );
+    }
+
+    /**
+     * @notice Test Phase 1: Deposit native with srcHook
+     */
+    function testPhase1_DepositNativeWithSrcHook() public {
+        uint256 initialUserNative = userSource.balance;
+        
+        _depositNativeWithSrcHook();
+        
+        // Verify user spent native ETH
+        assertEq(
+            userSource.balance,
+            initialUserNative - INPUT_AMOUNT,
+            "User should spend native ETH"
+        );
+        
+        // Verify converted tokens are locked
+        assertEq(
+            localAori.getLockedBalances(userSource, address(convertedToken)),
+            HOOK_CONVERTED_AMOUNT,
+            "Converted tokens should be locked for user"
+        );
+        
+        // Verify order status
+        assertTrue(
+            localAori.orderStatus(localAori.hash(order)) == IAori.OrderStatus.Active,
+            "Order should be Active"
+        );
+    }
+
+    /**
+     * @notice Test Phase 2: Fill directly without hook
+     */
+    function testPhase2_FillWithoutHook() public {
+        _depositNativeWithSrcHook();
+        
+        uint256 initialUserOutput = outputToken.balanceOf(userDest);
+        uint256 initialSolverOutput = outputToken.balanceOf(solverDest);
+        
+        _fillOrderDirectly();
+        
+        // Verify user received output tokens
+        assertEq(
+            outputToken.balanceOf(userDest),
+            initialUserOutput + OUTPUT_AMOUNT,
+            "User should receive output tokens"
+        );
+        
+        // Verify solver spent output tokens
+        assertEq(
+            outputToken.balanceOf(solverDest),
+            initialSolverOutput - OUTPUT_AMOUNT,
+            "Solver should spend output tokens"
+        );
+        
+        // Verify order status
+        assertTrue(
+            remoteAori.orderStatus(localAori.hash(order)) == IAori.OrderStatus.Filled,
+            "Order should be Filled"
+        );
+    }
+
+    /**
+     * @notice Test Phase 3: Settlement via LayerZero
+     */
+    function testPhase3_Settlement() public {
+        _depositNativeWithSrcHook();
+        _fillOrderDirectly();
+        _settleOrder();
+        _simulateLzMessageDelivery();
+        
+        // Verify order status on source chain
+        vm.chainId(localEid);
+        assertTrue(
+            localAori.orderStatus(localAori.hash(order)) == IAori.OrderStatus.Settled,
+            "Order should be Settled"
+        );
+        
+        // Verify locked balance is cleared
+        assertEq(
+            localAori.getLockedBalances(userSource, address(convertedToken)),
+            0,
+            "User should have no locked balance after settlement"
+        );
+        
+        // Verify solver has unlocked balance
+        assertEq(
+            localAori.getUnlockedBalances(solverSource, address(convertedToken)),
+            HOOK_CONVERTED_AMOUNT,
+            "Solver should have unlocked converted tokens"
+        );
+    }
+
+    /**
+     * @notice Test Phase 4: Solver withdrawal
+     */
+    function testPhase4_SolverWithdrawal() public {
+        _depositNativeWithSrcHook();
+        _fillOrderDirectly();
+        _settleOrder();
+        _simulateLzMessageDelivery();
+        
+        // Switch to source chain for withdrawal
+        vm.chainId(localEid);
+        
+        uint256 solverBalanceBefore = convertedToken.balanceOf(solverSource);
+        
+        // Solver withdraws earned tokens
+        vm.prank(solverSource);
+        localAori.withdraw(address(convertedToken), HOOK_CONVERTED_AMOUNT);
+        
+        // Verify withdrawal
+        assertEq(
+            convertedToken.balanceOf(solverSource),
+            solverBalanceBefore + HOOK_CONVERTED_AMOUNT,
+            "Solver should receive withdrawn tokens"
+        );
+        
+        assertEq(
+            localAori.getUnlockedBalances(solverSource, address(convertedToken)),
+            0,
+            "Solver should have no remaining unlocked balance"
+        );
+    }
+
+    /**
+     * @notice Full end-to-end test with detailed logging
+     */
+    function testCrossChainNativeHookToDirectFillSuccess() public {
+        console.log("=== CROSS-CHAIN NATIVE + SRCHOOK TO DIRECT FILL TEST ===");
+        console.log("Flow: User deposits 1 ETH + srcHook (converts to 1500 tokens) -> Solver fills 1000 tokens directly -> Settlement -> Solver withdraws");
+        console.log("");
+
+        // === PHASE 0: INITIAL STATE ===
+        vm.chainId(localEid);
+        uint256 initialUserNative = userSource.balance;
+        uint256 initialSolverConvertedTokens = convertedToken.balanceOf(solverSource);
+        uint256 initialContractConvertedTokens = convertedToken.balanceOf(address(localAori));
+        
+        vm.chainId(remoteEid);
+        uint256 initialUserOutput = outputToken.balanceOf(userDest);
+        uint256 initialSolverOutput = outputToken.balanceOf(solverDest);
+        
+        console.log("=== PHASE 0: INITIAL STATE ===");
+        console.log("Source Chain:");
+        console.log("  User native balance:", initialUserNative / 1e18, "ETH");
+        console.log("  Solver converted token balance:", initialSolverConvertedTokens / 1e18, "tokens");
+        console.log("Destination Chain:");
+        console.log("  User output tokens:", initialUserOutput / 1e18, "tokens");
+        console.log("  Solver output tokens:", initialSolverOutput / 1e18, "tokens");
+        console.log("");
+
+        // === PHASE 1: DEPOSIT WITH SRCHOOK ===
+        console.log("=== PHASE 1: USER DEPOSITS NATIVE ETH WITH SRCHOOK ===");
+        _depositNativeWithSrcHook();
+        
+        vm.chainId(localEid);
+        uint256 afterDepositUserNative = userSource.balance;
+        uint256 afterDepositLockedTokens = localAori.getLockedBalances(userSource, address(convertedToken));
+        uint256 afterDepositContractTokens = convertedToken.balanceOf(address(localAori));
+        
+        console.log("After Deposit:");
+        console.log("  User native balance:", afterDepositUserNative / 1e18, "ETH");
+        console.log("    Change:", formatETH(int256(afterDepositUserNative) - int256(initialUserNative)));
+        console.log("  User locked (converted) tokens:", afterDepositLockedTokens / 1e18, "tokens");
+        console.log("  Contract converted token balance:", afterDepositContractTokens / 1e18, "tokens");
+        console.log("    Change:", formatTokens(int256(afterDepositContractTokens) - int256(initialContractConvertedTokens)));
+        console.log("  Hook conversion: 1 ETH -> 1500 converted tokens");
+        console.log("");
+        
+        // Verify deposit state
+        assertTrue(localAori.orderStatus(localAori.hash(order)) == IAori.OrderStatus.Active, "Order should be Active");
+
+        // === PHASE 2: FILL DIRECTLY (NO HOOK) ===
+        console.log("=== PHASE 2: SOLVER FILLS DIRECTLY ON DESTINATION (NO HOOK) ===");
+        _fillOrderDirectly();
+        
+        vm.chainId(remoteEid);
+        uint256 afterFillUserOutput = outputToken.balanceOf(userDest);
+        uint256 afterFillSolverOutput = outputToken.balanceOf(solverDest);
+        
+        console.log("After Fill:");
+        console.log("  User output tokens:", afterFillUserOutput / 1e18, "tokens");
+        console.log("    Change:", formatTokens(int256(afterFillUserOutput) - int256(initialUserOutput)));
+        console.log("  Solver output tokens:", afterFillSolverOutput / 1e18, "tokens");
+        console.log("    Change:", formatTokens(int256(afterFillSolverOutput) - int256(initialSolverOutput)));
+        console.log("");
+        
+        // Verify fill state
+        assertTrue(remoteAori.orderStatus(localAori.hash(order)) == IAori.OrderStatus.Filled, "Order should be Filled");
+
+        // === PHASE 3: SETTLEMENT ===
+        console.log("=== PHASE 3: SETTLEMENT VIA LAYERZERO ===");
+        _settleOrder();
+        _simulateLzMessageDelivery();
+        
+        vm.chainId(localEid);
+        uint256 afterSettleLockedTokens = localAori.getLockedBalances(userSource, address(convertedToken));
+        uint256 afterSettleUnlockedTokens = localAori.getUnlockedBalances(solverSource, address(convertedToken));
+        
+        console.log("After Settlement:");
+        console.log("  User locked tokens:", afterSettleLockedTokens / 1e18, "tokens (should be 0)");
+        console.log("  Solver unlocked tokens:", afterSettleUnlockedTokens / 1e18, "tokens");
+        console.log("");
+        
+        // Verify settlement state
+        assertTrue(localAori.orderStatus(localAori.hash(order)) == IAori.OrderStatus.Settled, "Order should be Settled");
+
+        // === PHASE 4: WITHDRAWAL ===
+        console.log("=== PHASE 4: SOLVER WITHDRAWS EARNED TOKENS ===");
+        
+        uint256 beforeWithdrawSolverTokens = convertedToken.balanceOf(solverSource);
+        vm.prank(solverSource);
+        localAori.withdraw(address(convertedToken), HOOK_CONVERTED_AMOUNT);
+        
+        uint256 afterWithdrawSolverTokens = convertedToken.balanceOf(solverSource);
+        uint256 afterWithdrawUnlockedTokens = localAori.getUnlockedBalances(solverSource, address(convertedToken));
+        
+        console.log("After Withdrawal:");
+        console.log("  Solver converted token balance:", afterWithdrawSolverTokens / 1e18, "tokens");
+        console.log("    Change:", formatTokens(int256(afterWithdrawSolverTokens) - int256(beforeWithdrawSolverTokens)));
+        console.log("  Solver unlocked balance:", afterWithdrawUnlockedTokens / 1e18, "tokens (should be 0)");
+        console.log("");
+
+        // === FINAL SUMMARY ===
+        console.log("=== FINAL SUMMARY ===");
+        console.log("User:");
+        console.log("  Spent:", INPUT_AMOUNT / 1e18, "ETH on source chain");
+        console.log("  Received:", OUTPUT_AMOUNT / 1e18, "output tokens on destination chain");
+        console.log("Solver:");
+        console.log("  Spent:", OUTPUT_AMOUNT / 1e18, "output tokens on destination chain");
+        console.log("  Received:", HOOK_CONVERTED_AMOUNT / 1e18, "converted tokens on source chain");
+        console.log("  Profit:", (HOOK_CONVERTED_AMOUNT - OUTPUT_AMOUNT) / 1e18, "tokens (1500 - 1000 = 500)");
+        console.log("");
+
+        // Final assertions
+        assertEq(userSource.balance, initialUserNative - INPUT_AMOUNT, "User spent 1 ETH");
+        assertEq(outputToken.balanceOf(userDest), initialUserOutput + OUTPUT_AMOUNT, "User received 1000 output tokens");
+        assertEq(convertedToken.balanceOf(solverSource), initialSolverConvertedTokens + HOOK_CONVERTED_AMOUNT, "Solver received 1500 converted tokens");
+        assertEq(outputToken.balanceOf(solverDest), initialSolverOutput - OUTPUT_AMOUNT, "Solver spent 1000 output tokens");
+        
+        console.log("All assertions passed!");
+    }
+
+    /**
+     * @notice Test revert when srcHook output is insufficient
+     */
+    function testRevertInsufficientSrcHookOutput() public {
+        _createOrder();
+        
+        // Create hook that outputs less than minimum
+        IAori.SrcHook memory badHook = IAori.SrcHook({
+            hookAddress: address(mockHook2),
+            preferredToken: address(convertedToken),
+            minPreferedTokenAmountOut: MIN_PREFERRED_OUT,
+            instructions: abi.encodeWithSelector(
+                MockHook2.handleHook.selector,
+                address(convertedToken),
+                MIN_PREFERRED_OUT - 1  // Less than minimum
+            ),
+            solver: solverSource
+        });
+
+        vm.prank(userSource);
+        vm.expectRevert("Insufficient output from hook");
+        localAori.depositNative{value: INPUT_AMOUNT}(order, badHook);
+    }
+}
+

--- a/test/foundry/CC_NativeHookToHookFill.t.sol
+++ b/test/foundry/CC_NativeHookToHookFill.t.sol
@@ -1,0 +1,583 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+/**
+ * @title End-to-End Test: Cross-Chain Native + SrcHook → Fill with DstHook
+ * @notice Tests the complete double-hook flow:
+ *   1. Source Chain: depositNative(order, srcHook) - User deposits native ETH
+ *   2. Source Chain: SrcHook converts ETH to preferred token (e.g., USDC), locks it
+ *   3. Destination Chain: fill(order, dstHook) - Solver fills with hook conversion
+ *   4. Destination Chain: DstHook converts solver's preferred token to output token
+ *   5. User receives exact outputAmount, solver receives surplus from dstHook
+ *   6. Settlement: LayerZero message unlocks srcHook's preferred tokens for solver on source chain
+ *   7. Solver withdraws preferred tokens on source chain
+ * @dev Verifies both hooks execute correctly, balance accounting, and cross-chain messaging
+ * 
+ * @dev To run with detailed accounting logs:
+ *   forge test --match-test testCrossChainNativeHookToHookFillSuccess -vv
+ */
+import {Aori, IAori} from "../../contracts/Aori.sol";
+import {Origin} from "@layerzerolabs/oapp-evm/contracts/oapp/OApp.sol";
+import {TestUtils} from "./TestUtils.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {Test} from "forge-std/Test.sol";
+import {console} from "forge-std/console.sol";
+import {MockHook2} from "../Mock/MockHook2.sol";
+import "../../contracts/AoriUtils.sol";
+
+contract CC_NativeHookToHookFill_Test is TestUtils {
+    using NativeTokenUtils for address;
+
+    // Test amounts
+    uint128 public constant INPUT_AMOUNT = 1 ether;           // Native ETH input (user deposits)
+    uint128 public constant OUTPUT_AMOUNT = 1 ether;          // Native ETH output (user receives on dest)
+    uint128 public constant SRC_HOOK_OUTPUT = 1500e18;        // srcHook converts ETH to this many tokens
+    uint128 public constant MIN_SRC_PREFERRED_OUT = 1400e18;  // Minimum acceptable from srcHook
+    uint128 public constant DST_PREFERRED_AMOUNT = 10000e6;   // Solver's preferred token for dstHook (6 decimals)
+    uint128 public constant DST_HOOK_OUTPUT = 1.1 ether;      // dstHook converts to this much native ETH
+    uint128 public constant EXPECTED_SURPLUS = 0.1 ether;     // Surplus to solver (1.1 - 1.0)
+
+    // Cross-chain addresses
+    address public userSource;     // User on source chain
+    address public userDest;       // User on destination chain
+    address public solverSource;   // Solver on source chain
+    address public solverDest;     // Solver on destination chain
+
+    // Private keys for signing
+    uint256 public userSourcePrivKey = 0xABCD;
+    uint256 public solverSourcePrivKey = 0xDEAD;
+    uint256 public solverDestPrivKey = 0xBEEF;
+
+    // Order details
+    IAori.Order private order;
+    MockHook2 private srcMockHook;
+    MockHook2 private dstMockHook;
+
+    /**
+     * @notice Helper function to format wei amount to ETH string
+     */
+    function formatETH(int256 weiAmount) internal pure returns (string memory) {
+        if (weiAmount == 0) return "0 ETH";
+        
+        bool isNegative = weiAmount < 0;
+        uint256 absAmount = uint256(isNegative ? -weiAmount : weiAmount);
+        
+        uint256 ethPart = absAmount / 1e18;
+        uint256 weiPart = absAmount % 1e18;
+        
+        string memory sign = isNegative ? "-" : "+";
+        
+        if (weiPart == 0) {
+            return string(abi.encodePacked(sign, vm.toString(ethPart), " ETH"));
+        } else {
+            uint256 decimals = weiPart / 1e12;
+            return string(abi.encodePacked(sign, vm.toString(ethPart), ".", vm.toString(decimals), " ETH"));
+        }
+    }
+
+    /**
+     * @notice Helper function to format token amount (18 decimals) to readable string
+     */
+    function formatTokens18(int256 tokenAmount) internal pure returns (string memory) {
+        if (tokenAmount == 0) return "0 tokens";
+        
+        bool isNegative = tokenAmount < 0;
+        uint256 absAmount = uint256(isNegative ? -tokenAmount : tokenAmount);
+        
+        uint256 tokenPart = absAmount / 1e18;
+        uint256 decimalPart = absAmount % 1e18;
+        
+        string memory sign = isNegative ? "-" : "+";
+        
+        if (decimalPart == 0) {
+            return string(abi.encodePacked(sign, vm.toString(tokenPart), " tokens"));
+        } else {
+            uint256 decimals = decimalPart / 1e16;
+            return string(abi.encodePacked(sign, vm.toString(tokenPart), ".", vm.toString(decimals), " tokens"));
+        }
+    }
+
+    /**
+     * @notice Helper function to format token amount (6 decimals) to readable string
+     */
+    function formatTokens6(int256 tokenAmount) internal pure returns (string memory) {
+        if (tokenAmount == 0) return "0 tokens";
+        
+        bool isNegative = tokenAmount < 0;
+        uint256 absAmount = uint256(isNegative ? -tokenAmount : tokenAmount);
+        
+        uint256 tokenPart = absAmount / 1e6;
+        uint256 decimalPart = absAmount % 1e6;
+        
+        string memory sign = isNegative ? "-" : "+";
+        
+        if (decimalPart == 0) {
+            return string(abi.encodePacked(sign, vm.toString(tokenPart), " tokens"));
+        } else {
+            uint256 decimals = decimalPart / 1e4;
+            return string(abi.encodePacked(sign, vm.toString(tokenPart), ".", vm.toString(decimals), " tokens"));
+        }
+    }
+
+    function setUp() public override {
+        super.setUp();
+        
+        // Derive addresses from private keys
+        userSource = vm.addr(userSourcePrivKey);
+        solverSource = vm.addr(solverSourcePrivKey);
+        solverDest = vm.addr(solverDestPrivKey);
+        userDest = makeAddr("userDest");
+        
+        // Deploy separate hooks for source and destination
+        srcMockHook = new MockHook2();
+        dstMockHook = new MockHook2();
+        
+        // Setup native token balances for source chain
+        vm.deal(userSource, 5 ether);
+        vm.deal(solverSource, 1 ether);
+        
+        // Setup destination chain balances
+        vm.deal(userDest, 0 ether);
+        vm.deal(solverDest, 1 ether);
+        
+        // Setup contract balances
+        vm.deal(address(localAori), 0 ether);
+        vm.deal(address(remoteAori), 0 ether);
+        
+        // Give srcHook the converted token to output (ETH -> converted token)
+        convertedToken.mint(address(srcMockHook), 5000e18);
+        
+        // Give dstHook native ETH to output (preferred token -> native ETH)
+        vm.deal(address(dstMockHook), 5 ether);
+        
+        // Give solver preferred tokens for dstHook input
+        dstPreferredToken.mint(solverDest, 50000e6); // 6 decimals
+        
+        // Add hooks to allowed list
+        localAori.addAllowedHook(address(srcMockHook));
+        remoteAori.addAllowedHook(address(dstMockHook));
+        
+        // Add solvers to allowed list
+        localAori.addAllowedSolver(solverSource);
+        remoteAori.addAllowedSolver(solverDest);
+    }
+
+    /**
+     * @notice Helper to create order for native input -> native output (cross-chain)
+     */
+    function _createOrder() internal {
+        vm.chainId(localEid);
+        
+        order = createCustomOrder(
+            userSource,                      // offerer
+            userDest,                        // recipient (different chain)
+            NATIVE_TOKEN,                    // inputToken (native ETH)
+            NATIVE_TOKEN,                    // outputToken (native ETH)
+            INPUT_AMOUNT,                    // inputAmount
+            OUTPUT_AMOUNT,                   // outputAmount
+            block.timestamp,                 // startTime
+            block.timestamp + 1 hours,       // endTime
+            localEid,                        // srcEid
+            remoteEid                        // dstEid (cross-chain)
+        );
+    }
+
+    /**
+     * @notice Helper to create srcHook that converts native ETH to preferred token
+     */
+    function _createSrcHook() internal view returns (IAori.SrcHook memory) {
+        return IAori.SrcHook({
+            hookAddress: address(srcMockHook),
+            preferredToken: address(convertedToken),   // Hook outputs this ERC20
+            minPreferedTokenAmountOut: MIN_SRC_PREFERRED_OUT,
+            instructions: abi.encodeWithSelector(
+                MockHook2.handleHook.selector,
+                address(convertedToken),       // Output converted token
+                SRC_HOOK_OUTPUT                // Amount of tokens to output
+            ),
+            solver: solverSource
+        });
+    }
+
+    /**
+     * @notice Helper to create dstHook that converts preferred token to native ETH
+     */
+    function _createDstHook() internal view returns (IAori.DstHook memory) {
+        return IAori.DstHook({
+            hookAddress: address(dstMockHook),
+            preferredToken: address(dstPreferredToken), // Solver's preferred ERC20 (input)
+            instructions: abi.encodeWithSelector(
+                MockHook2.handleHook.selector,
+                NATIVE_TOKEN,              // Output native tokens
+                DST_HOOK_OUTPUT            // Amount of native to output
+            ),
+            preferedDstInputAmount: DST_PREFERRED_AMOUNT
+        });
+    }
+
+    /**
+     * @notice Helper to deposit native with srcHook
+     */
+    function _depositNativeWithSrcHook() internal {
+        _createOrder();
+        IAori.SrcHook memory srcHook = _createSrcHook();
+
+        vm.prank(userSource);
+        localAori.depositNative{value: INPUT_AMOUNT}(order, srcHook);
+    }
+
+    /**
+     * @notice Helper to fill order with dstHook
+     */
+    function _fillOrderWithDstHook() internal {
+        vm.chainId(remoteEid);
+        vm.warp(order.startTime + 1);
+
+        IAori.DstHook memory dstHook = _createDstHook();
+
+        // Approve solver's preferred tokens
+        vm.prank(solverDest);
+        dstPreferredToken.approve(address(remoteAori), DST_PREFERRED_AMOUNT);
+        
+        // Fill with dstHook
+        vm.prank(solverDest);
+        remoteAori.fill(order, dstHook);
+    }
+
+    /**
+     * @notice Helper to settle order via LayerZero
+     */
+    function _settleOrder() internal {
+        bytes memory options = defaultOptions();
+        uint256 fee = remoteAori.quote(localEid, 0, options, false, localEid, solverDest);
+        vm.deal(solverDest, fee);
+        vm.prank(solverDest);
+        remoteAori.settle{value: fee}(localEid, solverDest, options);
+    }
+
+    /**
+     * @notice Helper to simulate LayerZero message delivery
+     */
+    function _simulateLzMessageDelivery() internal {
+        vm.chainId(localEid);
+        bytes32 guid = keccak256("mock-guid");
+        bytes memory settlementPayload = abi.encodePacked(
+            uint8(0), // message type 0 for settlement
+            solverSource, // filler address (should be source chain solver for settlement)
+            uint16(1), // fill count
+            localAori.hash(order) // order hash
+        );
+
+        vm.prank(address(endpoints[localEid]));
+        localAori.lzReceive(
+            Origin(remoteEid, bytes32(uint256(uint160(address(remoteAori)))), 1),
+            guid,
+            settlementPayload,
+            address(0),
+            bytes("")
+        );
+    }
+
+    /**
+     * @notice Test Phase 1: Deposit native with srcHook
+     */
+    function testPhase1_DepositNativeWithSrcHook() public {
+        uint256 initialUserNative = userSource.balance;
+        
+        _depositNativeWithSrcHook();
+        
+        // Verify user spent native ETH
+        assertEq(
+            userSource.balance,
+            initialUserNative - INPUT_AMOUNT,
+            "User should spend native ETH"
+        );
+        
+        // Verify converted tokens are locked
+        assertEq(
+            localAori.getLockedBalances(userSource, address(convertedToken)),
+            SRC_HOOK_OUTPUT,
+            "Converted tokens should be locked for user"
+        );
+        
+        // Verify order status
+        assertTrue(
+            localAori.orderStatus(localAori.hash(order)) == IAori.OrderStatus.Active,
+            "Order should be Active"
+        );
+    }
+
+    /**
+     * @notice Test Phase 2: Fill with dstHook
+     */
+    function testPhase2_FillWithDstHook() public {
+        _depositNativeWithSrcHook();
+        
+        uint256 initialUserNative = userDest.balance;
+        uint256 initialSolverPreferred = dstPreferredToken.balanceOf(solverDest);
+        
+        _fillOrderWithDstHook();
+        
+        // Verify user received exact output amount
+        assertEq(
+            userDest.balance,
+            initialUserNative + OUTPUT_AMOUNT,
+            "User should receive exact output amount"
+        );
+        
+        // Verify solver received surplus from hook
+        // Note: solver also pays gas, so we check surplus went somewhere
+        // The surplus goes to msg.sender (solver) in the fill with dstHook
+        // But gas costs may obscure this, so we verify the hook output matches expectations
+        
+        // Verify solver spent preferred tokens
+        assertEq(
+            dstPreferredToken.balanceOf(solverDest),
+            initialSolverPreferred - DST_PREFERRED_AMOUNT,
+            "Solver should spend preferred tokens"
+        );
+        
+        // Verify order status
+        assertTrue(
+            remoteAori.orderStatus(localAori.hash(order)) == IAori.OrderStatus.Filled,
+            "Order should be Filled"
+        );
+    }
+
+    /**
+     * @notice Test Phase 3: Settlement via LayerZero
+     */
+    function testPhase3_Settlement() public {
+        _depositNativeWithSrcHook();
+        _fillOrderWithDstHook();
+        _settleOrder();
+        _simulateLzMessageDelivery();
+        
+        // Verify order status on source chain
+        vm.chainId(localEid);
+        assertTrue(
+            localAori.orderStatus(localAori.hash(order)) == IAori.OrderStatus.Settled,
+            "Order should be Settled"
+        );
+        
+        // Verify locked balance is cleared
+        assertEq(
+            localAori.getLockedBalances(userSource, address(convertedToken)),
+            0,
+            "User should have no locked balance after settlement"
+        );
+        
+        // Verify solver has unlocked balance
+        assertEq(
+            localAori.getUnlockedBalances(solverSource, address(convertedToken)),
+            SRC_HOOK_OUTPUT,
+            "Solver should have unlocked converted tokens"
+        );
+    }
+
+    /**
+     * @notice Test Phase 4: Solver withdrawal
+     */
+    function testPhase4_SolverWithdrawal() public {
+        _depositNativeWithSrcHook();
+        _fillOrderWithDstHook();
+        _settleOrder();
+        _simulateLzMessageDelivery();
+        
+        vm.chainId(localEid);
+        
+        uint256 solverBalanceBefore = convertedToken.balanceOf(solverSource);
+        
+        vm.prank(solverSource);
+        localAori.withdraw(address(convertedToken), SRC_HOOK_OUTPUT);
+        
+        assertEq(
+            convertedToken.balanceOf(solverSource),
+            solverBalanceBefore + SRC_HOOK_OUTPUT,
+            "Solver should receive withdrawn tokens"
+        );
+        
+        assertEq(
+            localAori.getUnlockedBalances(solverSource, address(convertedToken)),
+            0,
+            "Solver should have no remaining unlocked balance"
+        );
+    }
+
+    /**
+     * @notice Full end-to-end test with detailed logging
+     */
+    function testCrossChainNativeHookToHookFillSuccess() public {
+        console.log("=== CROSS-CHAIN NATIVE + SRCHOOK TO DSTHOOK FILL TEST ===");
+        console.log("Flow:");
+        console.log("  1. User deposits 1 ETH with srcHook (converts to 1500 tokens)");
+        console.log("  2. Solver fills with dstHook (10000 preferred -> 1.1 ETH)");
+        console.log("  3. User receives 1 ETH, solver receives 0.1 ETH surplus on dest");
+        console.log("  4. Settlement unlocks 1500 tokens for solver on source");
+        console.log("");
+
+        // === PHASE 0: INITIAL STATE ===
+        vm.chainId(localEid);
+        uint256 initialUserSourceNative = userSource.balance;
+        uint256 initialSolverConvertedTokens = convertedToken.balanceOf(solverSource);
+        
+        vm.chainId(remoteEid);
+        uint256 initialUserDestNative = userDest.balance;
+        uint256 initialSolverDestNative = solverDest.balance;
+        uint256 initialSolverPreferred = dstPreferredToken.balanceOf(solverDest);
+        
+        console.log("=== PHASE 0: INITIAL STATE ===");
+        console.log("Source Chain:");
+        console.log("  User native balance:", initialUserSourceNative / 1e18, "ETH");
+        console.log("  Solver converted token balance:", initialSolverConvertedTokens / 1e18, "tokens");
+        console.log("Destination Chain:");
+        console.log("  User native balance:", initialUserDestNative / 1e18, "ETH");
+        console.log("  Solver native balance:", initialSolverDestNative / 1e18, "ETH");
+        console.log("  Solver preferred tokens:", initialSolverPreferred / 1e6, "tokens");
+        console.log("");
+
+        // === PHASE 1: DEPOSIT WITH SRCHOOK ===
+        console.log("=== PHASE 1: USER DEPOSITS NATIVE ETH WITH SRCHOOK ===");
+        _depositNativeWithSrcHook();
+        
+        vm.chainId(localEid);
+        uint256 afterDepositUserNative = userSource.balance;
+        uint256 afterDepositLockedTokens = localAori.getLockedBalances(userSource, address(convertedToken));
+        
+        console.log("After Deposit:");
+        console.log("  User native balance:", afterDepositUserNative / 1e18, "ETH");
+        console.log("    Change:", formatETH(int256(afterDepositUserNative) - int256(initialUserSourceNative)));
+        console.log("  User locked (converted) tokens:", afterDepositLockedTokens / 1e18, "tokens");
+        console.log("  srcHook conversion: 1 ETH -> 1500 converted tokens");
+        console.log("");
+        
+        assertTrue(localAori.orderStatus(localAori.hash(order)) == IAori.OrderStatus.Active, "Order should be Active");
+
+        // === PHASE 2: FILL WITH DSTHOOK ===
+        console.log("=== PHASE 2: SOLVER FILLS WITH DSTHOOK ===");
+        _fillOrderWithDstHook();
+        
+        vm.chainId(remoteEid);
+        uint256 afterFillUserDestNative = userDest.balance;
+        uint256 afterFillSolverPreferred = dstPreferredToken.balanceOf(solverDest);
+        
+        console.log("After Fill with DstHook:");
+        console.log("  User native balance:", afterFillUserDestNative / 1e18, "ETH");
+        console.log("    Change:", formatETH(int256(afterFillUserDestNative) - int256(initialUserDestNative)));
+        console.log("  Solver preferred tokens:", afterFillSolverPreferred / 1e6, "tokens");
+        console.log("    Change:", formatTokens6(int256(afterFillSolverPreferred) - int256(initialSolverPreferred)));
+        console.log("  dstHook conversion: 10000 preferred -> 1.1 ETH");
+        console.log("  User received: 1 ETH, Surplus to solver: 0.1 ETH");
+        console.log("");
+        
+        assertTrue(remoteAori.orderStatus(localAori.hash(order)) == IAori.OrderStatus.Filled, "Order should be Filled");
+
+        // === PHASE 3: SETTLEMENT ===
+        console.log("=== PHASE 3: SETTLEMENT VIA LAYERZERO ===");
+        _settleOrder();
+        _simulateLzMessageDelivery();
+        
+        vm.chainId(localEid);
+        uint256 afterSettleLockedTokens = localAori.getLockedBalances(userSource, address(convertedToken));
+        uint256 afterSettleUnlockedTokens = localAori.getUnlockedBalances(solverSource, address(convertedToken));
+        
+        console.log("After Settlement:");
+        console.log("  User locked tokens:", afterSettleLockedTokens / 1e18, "tokens (should be 0)");
+        console.log("  Solver unlocked tokens:", afterSettleUnlockedTokens / 1e18, "tokens");
+        console.log("");
+        
+        assertTrue(localAori.orderStatus(localAori.hash(order)) == IAori.OrderStatus.Settled, "Order should be Settled");
+
+        // === PHASE 4: WITHDRAWAL ===
+        console.log("=== PHASE 4: SOLVER WITHDRAWS EARNED TOKENS ===");
+        
+        uint256 beforeWithdrawSolverTokens = convertedToken.balanceOf(solverSource);
+        vm.prank(solverSource);
+        localAori.withdraw(address(convertedToken), SRC_HOOK_OUTPUT);
+        
+        uint256 afterWithdrawSolverTokens = convertedToken.balanceOf(solverSource);
+        
+        console.log("After Withdrawal:");
+        console.log("  Solver converted token balance:", afterWithdrawSolverTokens / 1e18, "tokens");
+        console.log("    Change:", formatTokens18(int256(afterWithdrawSolverTokens) - int256(beforeWithdrawSolverTokens)));
+        console.log("");
+
+        // === FINAL SUMMARY ===
+        console.log("=== FINAL SUMMARY ===");
+        console.log("User:");
+        console.log("  Spent: 1 ETH on source chain");
+        console.log("  Received: 1 ETH on destination chain");
+        console.log("Solver:");
+        console.log("  Source chain: Received 1500 converted tokens");
+        console.log("  Dest chain: Spent 10000 preferred tokens, received 0.1 ETH surplus");
+        console.log("");
+
+        // Final assertions
+        assertEq(userSource.balance, initialUserSourceNative - INPUT_AMOUNT, "User spent 1 ETH on source");
+        assertEq(userDest.balance, initialUserDestNative + OUTPUT_AMOUNT, "User received 1 ETH on dest");
+        assertEq(convertedToken.balanceOf(solverSource), initialSolverConvertedTokens + SRC_HOOK_OUTPUT, "Solver received converted tokens");
+        assertEq(dstPreferredToken.balanceOf(solverDest), initialSolverPreferred - DST_PREFERRED_AMOUNT, "Solver spent preferred tokens");
+        
+        console.log("All assertions passed!");
+    }
+
+    /**
+     * @notice Test that both hooks execute correctly in sequence
+     */
+    function testBothHooksExecuteCorrectly() public {
+        // Track hook balances
+        uint256 srcHookInitialConverted = convertedToken.balanceOf(address(srcMockHook));
+        uint256 srcHookInitialNative = address(srcMockHook).balance;
+        uint256 dstHookInitialPreferred = dstPreferredToken.balanceOf(address(dstMockHook));
+        uint256 dstHookInitialNative = address(dstMockHook).balance;
+        
+        _depositNativeWithSrcHook();
+        _fillOrderWithDstHook();
+        
+        // Verify srcHook received native and sent converted
+        assertEq(
+            address(srcMockHook).balance,
+            srcHookInitialNative + INPUT_AMOUNT,
+            "srcHook should receive native ETH"
+        );
+        assertEq(
+            convertedToken.balanceOf(address(srcMockHook)),
+            srcHookInitialConverted - SRC_HOOK_OUTPUT,
+            "srcHook should send converted tokens"
+        );
+        
+        // Verify dstHook received preferred and sent native
+        assertEq(
+            dstPreferredToken.balanceOf(address(dstMockHook)),
+            dstHookInitialPreferred + DST_PREFERRED_AMOUNT,
+            "dstHook should receive preferred tokens"
+        );
+        assertEq(
+            address(dstMockHook).balance,
+            dstHookInitialNative - DST_HOOK_OUTPUT,
+            "dstHook should send native ETH"
+        );
+    }
+
+    /**
+     * @notice Test that user receives exact outputAmount and solver gets surplus
+     */
+    function testSurplusDistribution() public {
+        uint256 initialUserDestNative = userDest.balance;
+        
+        _depositNativeWithSrcHook();
+        _fillOrderWithDstHook();
+        
+        // User should receive exactly outputAmount
+        assertEq(
+            userDest.balance,
+            initialUserDestNative + OUTPUT_AMOUNT,
+            "User should receive exact outputAmount"
+        );
+        
+        // Surplus (0.1 ETH) should go to solver
+        // Note: Hard to verify exact solver native due to gas costs
+        // but we can verify the hook output the expected amount
+    }
+}
+

--- a/test/foundry/GasReport.t.sol
+++ b/test/foundry/GasReport.t.sol
@@ -93,7 +93,8 @@ contract GasReportTest is TestHelperOz5 {
             hookAddress: address(0),
             preferredToken: address(inputToken),
             minPreferedTokenAmountOut: 1000, // Arbitrary minimum amount since no conversion
-            instructions: ""
+            instructions: "",
+            solver: solver
         });
 
         commonDstData = IAori.DstHook({

--- a/test/foundry/SC_ERC20ToNativeHook.t.sol
+++ b/test/foundry/SC_ERC20ToNativeHook.t.sol
@@ -147,7 +147,8 @@ contract SC_ERC20ToNativeHook_Test is TestUtils {
                 MockHook2.handleHook.selector,
                 NATIVE_TOKEN,      // Output native tokens
                 HOOK_OUTPUT        // Amount of native tokens to output
-            )
+            ),
+            solver: solverSC
         });
 
         // User approves their input tokens to be spent by the contract
@@ -346,7 +347,8 @@ contract SC_ERC20ToNativeHook_Test is TestUtils {
                 MockHook2.handleHook.selector,
                 NATIVE_TOKEN,
                 HOOK_OUTPUT
-            )
+            ),
+            solver: solverSC
         });
 
         // User approves tokens
@@ -395,7 +397,8 @@ contract SC_ERC20ToNativeHook_Test is TestUtils {
                 MockHook2.handleHook.selector,
                 NATIVE_TOKEN,
                 OUTPUT_AMOUNT - 1  // Less than required
-            )
+            ),
+            solver: solverSC
         });
 
         vm.prank(userSC);
@@ -439,7 +442,8 @@ contract SC_ERC20ToNativeHook_Test is TestUtils {
                 MockHook2.handleHook.selector,
                 NATIVE_TOKEN,
                 customHookOutput
-            )
+            ),
+            solver: solverSC
         });
 
         uint256 initialUserNative = userSC.balance;
@@ -529,7 +533,8 @@ contract SC_ERC20ToNativeHook_Test is TestUtils {
                 MockHook2.handleHook.selector,
                 NATIVE_TOKEN,
                 customHookOutput
-            )
+            ),
+            solver: solverSC
         });
 
         vm.prank(userSC);

--- a/test/foundry/SC_ERC20ToNativeSrcHook.t.sol
+++ b/test/foundry/SC_ERC20ToNativeSrcHook.t.sol
@@ -148,7 +148,8 @@ contract SC_ERC20ToNativeSrcHook_Test is TestUtils {
                 MockHook2.handleHook.selector,
                 NATIVE_TOKEN,      // Output native tokens
                 HOOK_OUTPUT        // Amount of native tokens to output
-            )
+            ),
+            solver: solverSC
         });
 
         // User approves their input tokens to be spent by the contract
@@ -364,7 +365,8 @@ contract SC_ERC20ToNativeSrcHook_Test is TestUtils {
                 MockHook2.handleHook.selector,
                 NATIVE_TOKEN,
                 HOOK_OUTPUT
-            )
+            ),
+            solver: solverSC
         });
 
         // User approves tokens
@@ -413,7 +415,8 @@ contract SC_ERC20ToNativeSrcHook_Test is TestUtils {
                 MockHook2.handleHook.selector,
                 NATIVE_TOKEN,
                 OUTPUT_AMOUNT - 1  // Less than required
-            )
+            ),
+            solver: solverSC
         });
 
         vm.prank(userSC);
@@ -538,7 +541,8 @@ contract SC_ERC20ToNativeSrcHook_Test is TestUtils {
                 MockHook2.handleHook.selector,
                 NATIVE_TOKEN,
                 hookOutput  // Variable hook output
-            )
+            ),
+            solver: testSolver
         });
 
         // Record initial balances

--- a/test/foundry/SC_NativeHookAtomicSwap.t.sol
+++ b/test/foundry/SC_NativeHookAtomicSwap.t.sol
@@ -1,0 +1,460 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+/**
+ * @title End-to-End Test: Single-Chain Native Deposit with SrcHook (Atomic Settlement)
+ * @notice Tests the new depositNative(order, srcHook) execution path for single-chain swaps
+ * @dev Tests the complete flow:
+ *   1. User deposits native ETH using depositNative(order, srcHook)
+ *   2. SrcHook converts native ETH to output token (e.g., ERC20)
+ *   3. User receives outputAmount of output token
+ *   4. Solver (specified in hook.solver) receives any surplus from hook conversion
+ *   5. Atomic settlement - everything happens in one transaction
+ * @dev Verifies single-chain atomic settlement, direct token distribution, surplus to solver
+ * 
+ * @dev To run with detailed accounting logs:
+ *   forge test --match-test testSingleChainNativeWithHookSuccess -vv
+ */
+import {Aori, IAori} from "../../contracts/Aori.sol";
+import {TestUtils} from "./TestUtils.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {Test} from "forge-std/Test.sol";
+import {console} from "forge-std/console.sol";
+import {MockHook2} from "../Mock/MockHook2.sol";
+import "../../contracts/AoriUtils.sol";
+
+contract SC_NativeHookAtomicSwap_Test is TestUtils {
+    using NativeTokenUtils for address;
+
+    // Test amounts
+    uint128 public constant INPUT_AMOUNT = 1 ether;          // Native ETH input (user deposits)
+    uint128 public constant OUTPUT_AMOUNT = 1000e18;         // ERC20 output (user receives)
+    uint128 public constant HOOK_OUTPUT = 1100e18;           // Hook converts to this much ERC20
+    uint128 public constant EXPECTED_SURPLUS = 100e18;       // Surplus returned to solver (1100 - 1000 = 100)
+
+    // Single-chain addresses
+    address public userSC;     // User on single chain
+    address public solverSC;   // Solver on single chain
+
+    // Private keys for signing
+    uint256 public userSCPrivKey = 0xABCD;
+    uint256 public solverSCPrivKey = 0xDEAD;
+
+    // Order details
+    IAori.Order private order;
+    MockHook2 private mockHook2;
+
+    /**
+     * @notice Helper function to format wei amount to ETH string
+     */
+    function formatETH(int256 weiAmount) internal pure returns (string memory) {
+        if (weiAmount == 0) return "0 ETH";
+        
+        bool isNegative = weiAmount < 0;
+        uint256 absAmount = uint256(isNegative ? -weiAmount : weiAmount);
+        
+        uint256 ethPart = absAmount / 1e18;
+        uint256 weiPart = absAmount % 1e18;
+        
+        string memory sign = isNegative ? "-" : "+";
+        
+        if (weiPart == 0) {
+            return string(abi.encodePacked(sign, vm.toString(ethPart), " ETH"));
+        } else {
+            uint256 decimals = weiPart / 1e12;
+            return string(abi.encodePacked(sign, vm.toString(ethPart), ".", vm.toString(decimals), " ETH"));
+        }
+    }
+
+    /**
+     * @notice Helper function to format token amount to readable string
+     */
+    function formatTokens(int256 tokenAmount) internal pure returns (string memory) {
+        if (tokenAmount == 0) return "0 tokens";
+        
+        bool isNegative = tokenAmount < 0;
+        uint256 absAmount = uint256(isNegative ? -tokenAmount : tokenAmount);
+        
+        uint256 tokenPart = absAmount / 1e18;
+        uint256 decimalPart = absAmount % 1e18;
+        
+        string memory sign = isNegative ? "-" : "+";
+        
+        if (decimalPart == 0) {
+            return string(abi.encodePacked(sign, vm.toString(tokenPart), " tokens"));
+        } else {
+            uint256 decimals = decimalPart / 1e16;
+            return string(abi.encodePacked(sign, vm.toString(tokenPart), ".", vm.toString(decimals), " tokens"));
+        }
+    }
+
+    function setUp() public override {
+        super.setUp();
+        
+        // Derive addresses from private keys
+        userSC = vm.addr(userSCPrivKey);
+        solverSC = vm.addr(solverSCPrivKey);
+        
+        // Deploy MockHook2
+        mockHook2 = new MockHook2();
+        
+        // Setup native token balances
+        vm.deal(userSC, 5 ether);         // User has 5 ETH
+        vm.deal(solverSC, 1 ether);       // Solver has 1 ETH for gas
+        
+        // Setup contract balances (start clean)
+        vm.deal(address(localAori), 0 ether);
+        
+        // Give hook the output tokens to distribute (what hook outputs)
+        outputToken.mint(address(mockHook2), 5000e18); // 5000 output tokens for hook operations
+        
+        // Add MockHook2 to allowed hooks
+        localAori.addAllowedHook(address(mockHook2));
+        
+        // Add solver to allowed list
+        localAori.addAllowedSolver(solverSC);
+    }
+
+    /**
+     * @notice Helper function to create order for native input -> ERC20 output
+     */
+    function _createOrder() internal {
+        vm.chainId(localEid);
+        
+        order = createCustomOrder(
+            userSC,                      // offerer
+            userSC,                      // recipient (same as offerer for single-chain)
+            NATIVE_TOKEN,                // inputToken (native ETH)
+            address(outputToken),        // outputToken (ERC20)
+            INPUT_AMOUNT,                // inputAmount
+            OUTPUT_AMOUNT,               // outputAmount
+            block.timestamp,             // startTime
+            block.timestamp + 1 hours,   // endTime
+            localEid,                    // srcEid
+            localEid                     // dstEid (same chain)
+        );
+    }
+
+    /**
+     * @notice Helper function to create srcHook configuration
+     */
+    function _createSrcHook() internal view returns (IAori.SrcHook memory) {
+        return IAori.SrcHook({
+            hookAddress: address(mockHook2),
+            preferredToken: address(outputToken),     // Hook outputs ERC20 tokens
+            minPreferedTokenAmountOut: OUTPUT_AMOUNT, // Minimum tokens expected
+            instructions: abi.encodeWithSelector(
+                MockHook2.handleHook.selector,
+                address(outputToken),  // Output ERC20 tokens
+                HOOK_OUTPUT            // Amount of tokens to output
+            ),
+            solver: solverSC
+        });
+    }
+
+    /**
+     * @notice Helper function to execute depositNative with srcHook
+     */
+    function _executeDepositNativeWithHook() internal {
+        _createOrder();
+        IAori.SrcHook memory srcHook = _createSrcHook();
+
+        // User executes depositNative with srcHook
+        vm.prank(userSC);
+        localAori.depositNative{value: INPUT_AMOUNT}(order, srcHook);
+    }
+
+    /**
+     * @notice Test single-chain native deposit with srcHook (atomic settlement)
+     */
+    function testSingleChainNativeWithHookSuccess() public {
+        uint256 initialUserNative = userSC.balance;
+        uint256 initialUserTokens = outputToken.balanceOf(userSC);
+        uint256 initialSolverTokens = outputToken.balanceOf(solverSC);
+
+        _executeDepositNativeWithHook();
+
+        // Verify user spent native ETH
+        assertEq(
+            userSC.balance,
+            initialUserNative - INPUT_AMOUNT,
+            "User should spend native ETH"
+        );
+        
+        // Verify user received output tokens
+        assertEq(
+            outputToken.balanceOf(userSC),
+            initialUserTokens + OUTPUT_AMOUNT,
+            "User should receive output tokens"
+        );
+        
+        // Verify solver received surplus
+        assertEq(
+            outputToken.balanceOf(solverSC),
+            initialSolverTokens + EXPECTED_SURPLUS,
+            "Solver should receive surplus tokens"
+        );
+
+        // Verify order status is Settled
+        assertTrue(
+            localAori.orderStatus(localAori.hash(order)) == IAori.OrderStatus.Settled,
+            "Order should be Settled"
+        );
+    }
+
+    /**
+     * @notice Test that surplus correctly goes to hook.solver (not msg.sender)
+     */
+    function testSingleChainNativeHookSurplusToSolver() public {
+        uint256 initialSolverTokens = outputToken.balanceOf(solverSC);
+        uint256 initialUserTokens = outputToken.balanceOf(userSC);
+
+        _executeDepositNativeWithHook();
+
+        // User is msg.sender, but solver (from hook) should get surplus
+        uint256 userTokenGain = outputToken.balanceOf(userSC) - initialUserTokens;
+        uint256 solverTokenGain = outputToken.balanceOf(solverSC) - initialSolverTokens;
+
+        assertEq(userTokenGain, OUTPUT_AMOUNT, "User should receive exactly outputAmount");
+        assertEq(solverTokenGain, EXPECTED_SURPLUS, "Solver should receive exactly the surplus");
+    }
+
+    /**
+     * @notice Test revert when hook doesn't provide enough output
+     */
+    function testSingleChainNativeHookInsufficientOutput() public {
+        vm.chainId(localEid);
+        
+        order = createCustomOrder(
+            userSC,
+            userSC,
+            NATIVE_TOKEN,
+            address(outputToken),
+            INPUT_AMOUNT,
+            OUTPUT_AMOUNT,
+            block.timestamp,
+            block.timestamp + 1 hours,
+            localEid,
+            localEid
+        );
+
+        // Setup srcHook with insufficient output
+        IAori.SrcHook memory srcHook = IAori.SrcHook({
+            hookAddress: address(mockHook2),
+            preferredToken: address(outputToken),
+            minPreferedTokenAmountOut: OUTPUT_AMOUNT,
+            instructions: abi.encodeWithSelector(
+                MockHook2.handleHook.selector,
+                address(outputToken),
+                OUTPUT_AMOUNT - 1  // Less than required
+            ),
+            solver: solverSC
+        });
+
+        vm.prank(userSC);
+        vm.expectRevert("Insufficient output from hook");
+        localAori.depositNative{value: INPUT_AMOUNT}(order, srcHook);
+    }
+
+    /**
+     * @notice Test order status becomes Settled for single-chain
+     */
+    function testSingleChainNativeHookOrderStatus() public {
+        _executeDepositNativeWithHook();
+        
+        bytes32 orderId = localAori.hash(order);
+        assertTrue(
+            localAori.orderStatus(orderId) == IAori.OrderStatus.Settled,
+            "Single-chain swap should be immediately Settled"
+        );
+    }
+
+    /**
+     * @notice Test no locked balances after atomic settlement
+     */
+    function testSingleChainNativeHookNoLockedBalances() public {
+        _executeDepositNativeWithHook();
+        
+        // No locked balances should remain for atomic settlement
+        assertEq(
+            localAori.getLockedBalances(userSC, NATIVE_TOKEN),
+            0,
+            "User should have no locked native balance"
+        );
+        assertEq(
+            localAori.getLockedBalances(userSC, address(outputToken)),
+            0,
+            "User should have no locked output token balance"
+        );
+        assertEq(
+            localAori.getUnlockedBalances(solverSC, address(outputToken)),
+            0,
+            "Solver should have no unlocked balance in contract"
+        );
+    }
+
+    /**
+     * @notice Test hook mechanics - verify hook receives native and sends tokens
+     */
+    function testSingleChainNativeHookMechanics() public {
+        uint256 hookInitialNative = address(mockHook2).balance;
+        uint256 hookInitialTokens = outputToken.balanceOf(address(mockHook2));
+
+        _executeDepositNativeWithHook();
+
+        // Verify hook received native ETH and sent output tokens
+        assertEq(
+            address(mockHook2).balance,
+            hookInitialNative + INPUT_AMOUNT,
+            "Hook should receive native ETH"
+        );
+        assertEq(
+            outputToken.balanceOf(address(mockHook2)),
+            hookInitialTokens - HOOK_OUTPUT,
+            "Hook should send output tokens"
+        );
+    }
+
+    /**
+     * @notice Test revert when msg.sender is not the offerer
+     */
+    function testRevertNonOffererCannotDeposit() public {
+        _createOrder();
+        IAori.SrcHook memory srcHook = _createSrcHook();
+
+        // Try to deposit as solver instead of user
+        vm.deal(solverSC, 5 ether);
+        vm.prank(solverSC);
+        vm.expectRevert("Only offerer can deposit native tokens");
+        localAori.depositNative{value: INPUT_AMOUNT}(order, srcHook);
+    }
+
+    /**
+     * @notice Test revert when msg.value doesn't match inputAmount
+     */
+    function testRevertIncorrectNativeAmount() public {
+        _createOrder();
+        IAori.SrcHook memory srcHook = _createSrcHook();
+
+        vm.prank(userSC);
+        vm.expectRevert("Incorrect native amount");
+        localAori.depositNative{value: INPUT_AMOUNT - 1}(order, srcHook);
+    }
+
+    /**
+     * @notice Test revert when order inputToken is not native
+     */
+    function testRevertNonNativeInputToken() public {
+        vm.chainId(localEid);
+        
+        // Create order with ERC20 input (not native)
+        order = createCustomOrder(
+            userSC,
+            userSC,
+            address(inputToken),         // ERC20, not native
+            address(outputToken),
+            INPUT_AMOUNT,
+            OUTPUT_AMOUNT,
+            block.timestamp,
+            block.timestamp + 1 hours,
+            localEid,
+            localEid
+        );
+
+        IAori.SrcHook memory srcHook = _createSrcHook();
+
+        vm.prank(userSC);
+        vm.expectRevert("Order must specify native token");
+        localAori.depositNative{value: INPUT_AMOUNT}(order, srcHook);
+    }
+
+    /**
+     * @notice Test revert with non-whitelisted solver in hook
+     */
+    function testRevertNonWhitelistedSolver() public {
+        vm.chainId(localEid);
+        
+        _createOrder();
+        
+        address nonWhitelistedSolver = makeAddr("nonWhitelistedSolver");
+        
+        IAori.SrcHook memory srcHook = IAori.SrcHook({
+            hookAddress: address(mockHook2),
+            preferredToken: address(outputToken),
+            minPreferedTokenAmountOut: OUTPUT_AMOUNT,
+            instructions: abi.encodeWithSelector(
+                MockHook2.handleHook.selector,
+                address(outputToken),
+                HOOK_OUTPUT
+            ),
+            solver: nonWhitelistedSolver  // Not whitelisted
+        });
+
+        vm.prank(userSC);
+        vm.expectRevert("Invalid solver in hook");
+        localAori.depositNative{value: INPUT_AMOUNT}(order, srcHook);
+    }
+
+    /**
+     * @notice Full end-to-end test with detailed balance logging
+     */
+    function testSingleChainNativeWithHookFullFlow() public {
+        console.log("=== SINGLE-CHAIN NATIVE WITH SRCHOOK TEST ===");
+        console.log("Flow: User deposits 1 ETH -> SrcHook converts to 1100 tokens -> User gets 1000 tokens, solver gets 100 tokens -> Atomic settlement");
+        console.log("");
+
+        // Store initial balances
+        uint256 initialUserNative = userSC.balance;
+        uint256 initialUserTokens = outputToken.balanceOf(userSC);
+        uint256 initialSolverTokens = outputToken.balanceOf(solverSC);
+        uint256 initialHookNative = address(mockHook2).balance;
+        uint256 initialHookTokens = outputToken.balanceOf(address(mockHook2));
+
+        console.log("=== PHASE 0: INITIAL STATE ===");
+        console.log("User:");
+        console.log("  Native balance:", initialUserNative / 1e18, "ETH");
+        console.log("  Output tokens:", initialUserTokens / 1e18, "tokens");
+        console.log("Solver:");
+        console.log("  Output tokens:", initialSolverTokens / 1e18, "tokens");
+        console.log("Hook:");
+        console.log("  Native balance:", initialHookNative / 1e18, "ETH");
+        console.log("  Output tokens:", initialHookTokens / 1e18, "tokens");
+        console.log("");
+
+        // Execute deposit
+        console.log("=== PHASE 1: USER EXECUTES DEPOSITNATIVE WITH SRCHOOK ===");
+        _executeDepositNativeWithHook();
+
+        console.log("After Deposit & Atomic Settlement:");
+        console.log("User:");
+        console.log("  Native balance:", userSC.balance / 1e18, "ETH");
+        console.log("    Change:", formatETH(int256(userSC.balance) - int256(initialUserNative)));
+        console.log("  Output tokens:", outputToken.balanceOf(userSC) / 1e18, "tokens");
+        console.log("    Change:", formatTokens(int256(outputToken.balanceOf(userSC)) - int256(initialUserTokens)));
+        
+        console.log("Solver:");
+        console.log("  Output tokens:", outputToken.balanceOf(solverSC) / 1e18, "tokens");
+        console.log("    Change:", formatTokens(int256(outputToken.balanceOf(solverSC)) - int256(initialSolverTokens)));
+        
+        console.log("Hook:");
+        console.log("  Native balance:", address(mockHook2).balance / 1e18, "ETH");
+        console.log("    Change:", formatETH(int256(address(mockHook2).balance) - int256(initialHookNative)));
+        console.log("  Output tokens:", outputToken.balanceOf(address(mockHook2)) / 1e18, "tokens");
+        console.log("    Change:", formatTokens(int256(outputToken.balanceOf(address(mockHook2))) - int256(initialHookTokens)));
+        console.log("");
+
+        // Final assertions
+        console.log("=== FINAL ASSERTIONS ===");
+        
+        assertEq(userSC.balance, initialUserNative - INPUT_AMOUNT, "User spent 1 ETH");
+        assertEq(outputToken.balanceOf(userSC), initialUserTokens + OUTPUT_AMOUNT, "User received 1000 tokens");
+        assertEq(outputToken.balanceOf(solverSC), initialSolverTokens + EXPECTED_SURPLUS, "Solver received 100 token surplus");
+        assertEq(address(mockHook2).balance, initialHookNative + INPUT_AMOUNT, "Hook received 1 ETH");
+        assertEq(outputToken.balanceOf(address(mockHook2)), initialHookTokens - HOOK_OUTPUT, "Hook sent 1100 tokens");
+        
+        assertTrue(localAori.orderStatus(localAori.hash(order)) == IAori.OrderStatus.Settled, "Order is Settled");
+        
+        console.log("All assertions passed!");
+    }
+}
+

--- a/test/foundry/TestUtils.sol
+++ b/test/foundry/TestUtils.sol
@@ -270,7 +270,8 @@ contract TestUtils is TestHelperOz5 {
             hookAddress: address(mockHook),
             preferredToken: address(convertedToken),
             minPreferedTokenAmountOut: 1500,
-            instructions: abi.encodeWithSelector(MockHook.handleHook.selector, address(convertedToken), inputAmount)
+            instructions: abi.encodeWithSelector(MockHook.handleHook.selector, address(convertedToken), inputAmount),
+            solver: solver
         });
     }
 


### PR DESCRIPTION
##SrcHook Solver Field & Validation Consolidation

### What Changed

When users execute swaps through source hooks, the solver who provided the swap route now receives the trading surplus. Previously, surplus went to whoever submitted the transaction (msg.sender), which was incorrect for user-initiated native token swaps.

### Why
With the new depositNative function allowing users to self-execute, to retain feature parity, we needed a way to ensure the solver receives the surplus even when they're not the transaction sender, this is particularly relevant for singleChain atomic swaps executed with the nativeDeposit(

### How It Works
New solver field added to SrcHook struct - specifies who receives surplus
Validation - solver must be whitelisted (same as hook addresses)
Surplus distribution - output above the guaranteed amount goes to the specified solver

### Code Cleanup
Consolidated scattered hook validation into two clean functions:
`validateSrcHook()` - checks hook address + solver
`validateDstHook()` - checks hook address

Removed redundant code: `isSome()` helper functions and allowedHookAddress modifier.

### Breaking Change
Callers must now include a valid whitelisted solver address in SrcHook.solver when using hook-based deposits.