### PR TITLE
Consolidate native token validation and transfer into TokenUtils

### DIFF
--- a/contracts/Aori.sol
+++ b/contracts/Aori.sol
@@ -581,11 +581,7 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, ReentrancyGuardUpgradeable
         bytes32 orderId = order.validateFill(msg.sender, ENDPOINT_ID, this.orderStatus);
 
         // Validate payment method matches output token type
-        if (order.outputToken.isNativeToken()) {
-            if (msg.value != order.outputAmount) revert IncorrectNativeAmount(order.outputAmount, msg.value);
-        } else {
-            if (msg.value != 0) revert UnexpectedNativeTokens();
-        }
+        order.outputToken.validateMsgValue(order.outputAmount, msg.value);
 
         // Update contract state
         if (order.isSingleChainSwap()) {
@@ -595,11 +591,7 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, ReentrancyGuardUpgradeable
         }
 
         // Transfer tokens to recipient
-        if (order.outputToken.isNativeToken()) {
-            order.outputToken.safeTransfer(order.recipient, order.outputAmount);
-        } else {
-            IERC20(order.outputToken).safeTransferFrom(msg.sender, order.recipient, order.outputAmount);
-        }
+        order.outputToken.safeTransferFrom(msg.sender, order.recipient, order.outputAmount);
     }
 
     /**
@@ -649,15 +641,8 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, ReentrancyGuardUpgradeable
         hook.validateDstHook(this.isAllowedHook);
 
         if (hook.preferredDstInputAmount > 0) {
-            if (hook.preferredToken.isNativeToken()) {
-                if (msg.value != hook.preferredDstInputAmount) revert IncorrectNativeAmount(hook.preferredDstInputAmount, msg.value);
-                (bool success,) = payable(hook.hookAddress).call{ value: hook.preferredDstInputAmount }("");
-                if (!success) revert NativeTransferFailed();
-            } else {
-                // ERC20 token input - no native tokens should be sent
-                if (msg.value != 0) revert UnexpectedNativeTokens();
-                IERC20(hook.preferredToken).safeTransferFrom(msg.sender, hook.hookAddress, hook.preferredDstInputAmount);
-            }
+            hook.preferredToken.validateMsgValue(hook.preferredDstInputAmount, msg.value);
+            hook.preferredToken.safeTransferFrom(msg.sender, hook.hookAddress, hook.preferredDstInputAmount);
         } else {
             // Hook expects no input tokens - ensure no ETH was mistakenly sent
             if (msg.value != 0) revert UnexpectedNativeTokens();

--- a/contracts/libraries/internal/TokenUtils.sol
+++ b/contracts/libraries/internal/TokenUtils.sol
@@ -74,4 +74,43 @@ library TokenUtils {
             if (IERC20(token).balanceOf(address(this)) < amount) revert InsufficientContractBalance(token);
         }
     }
+
+    /**
+     * @notice Validates msg.value matches expected amount for token type
+     * @param token The token address (use NATIVE_TOKEN for ETH)
+     * @param expectedAmount The expected amount
+     * @param msgValue The msg.value to validate
+     */
+    function validateMsgValue(
+        address token,
+        uint256 expectedAmount,
+        uint256 msgValue
+    ) internal pure {
+        if (isNativeToken(token)) {
+            if (msgValue != expectedAmount) revert IncorrectNativeAmount(expectedAmount, msgValue);
+        } else {
+            if (msgValue != 0) revert UnexpectedNativeTokens();
+        }
+    }
+
+    /**
+     * @notice Transfers tokens from sender, handling native vs ERC20
+     * @param token The token address
+     * @param from The sender address
+     * @param to The recipient address
+     * @param amount The amount to transfer
+     */
+    function safeTransferFrom(
+        address token,
+        address from,
+        address to,
+        uint256 amount
+    ) internal {
+        if (isNativeToken(token)) {
+            (bool success,) = payable(to).call{ value: amount }("");
+            if (!success) revert NativeTransferFailed();
+        } else {
+            IERC20(token).safeTransferFrom(from, to, amount);
+        }
+    }
 }


### PR DESCRIPTION
Add `validateMsgValue()` and `safeTransferFrom()` to `TokenUtils`, saving 21 bytes (margin: 34→55 bytes)