### PR TITLE
Add executeTransfer() to Permit2Lib

### DIFF
--- a/contracts/Aori.sol
+++ b/contracts/Aori.sol
@@ -470,17 +470,7 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, ReentrancyGuardUpgradeable
 
         ValidationUtils.validateCommonOrderParams(order);
 
-        // Build Permit2 structs
-        ISignatureTransfer.PermitTransferFrom memory permit = Permit2Lib.buildPermit(order, nonce, deadline);
-        ISignatureTransfer.SignatureTransferDetails memory transferDetails =
-            Permit2Lib.buildTransferDetails(address(this), order.inputAmount);
-
-        bytes32 witness = Permit2Lib.hashOrder(order);
-
-        // Execute Permit2 transfer - this verifies the signature
-        // The user signed over: token, amount, nonce, deadline, spender (this contract), AND the order
-        ISignatureTransfer(Permit2Lib.PERMIT2)
-            .permitWitnessTransferFrom(permit, transferDetails, order.offerer, witness, Permit2Lib.WITNESS_TYPE_STRING, signature);
+        Permit2Lib.executeTransfer(order, address(this), nonce, deadline, signature);
 
         _postDeposit(order.inputToken, order.inputAmount, order, orderId);
     }
@@ -516,16 +506,7 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, ReentrancyGuardUpgradeable
 
         hook.validateSrcHook(this.isAllowedHook);
 
-        // Build Permit2 structs - transfer directly to hook
-        ISignatureTransfer.PermitTransferFrom memory permit = Permit2Lib.buildPermit(order, nonce, deadline);
-        ISignatureTransfer.SignatureTransferDetails memory transferDetails =
-            Permit2Lib.buildTransferDetails(hook.hookAddress, order.inputAmount);
-
-        bytes32 witness = Permit2Lib.hashOrder(order);
-
-        // Transfer tokens to hook via Permit2
-        ISignatureTransfer(Permit2Lib.PERMIT2)
-            .permitWitnessTransferFrom(permit, transferDetails, order.offerer, witness, Permit2Lib.WITNESS_TYPE_STRING, signature);
+        Permit2Lib.executeTransfer(order, hook.hookAddress, nonce, deadline, signature);
 
         // Execute hook conversion (tokens already at hook address)
         if (order.isSingleChainSwap()) {

--- a/contracts/libraries/internal/Permit2Lib.sol
+++ b/contracts/libraries/internal/Permit2Lib.sol
@@ -120,4 +120,26 @@ library Permit2Lib {
     ) internal pure returns (ISignatureTransfer.SignatureTransferDetails memory details) {
         details = ISignatureTransfer.SignatureTransferDetails({ to: to, requestedAmount: amount });
     }
+
+    /**
+     * @notice Execute Permit2 witness transfer
+     * @param order The order (used as witness)
+     * @param to Transfer recipient
+     * @param nonce Permit2 nonce
+     * @param deadline Signature deadline
+     * @param signature User's signature
+     */
+    function executeTransfer(
+        Order calldata order,
+        address to,
+        uint256 nonce,
+        uint256 deadline,
+        bytes calldata signature
+    ) internal {
+        ISignatureTransfer.PermitTransferFrom memory permit = buildPermit(order, nonce, deadline);
+        ISignatureTransfer.SignatureTransferDetails memory transferDetails = buildTransferDetails(to, order.inputAmount);
+        bytes32 witness = hashOrder(order);
+        ISignatureTransfer(PERMIT2)
+            .permitWitnessTransferFrom(permit, transferDetails, order.offerer, witness, WITNESS_TYPE_STRING, signature);
+    }
 }


### PR DESCRIPTION
Add `executeTransfer()` to Permit2Lib, saving 144 bytes (margin: 34→178 bytes)