### PR TITLE
Add distributeWithSurplus() to TokenUtils

### DIFF
--- a/contracts/Aori.sol
+++ b/contracts/Aori.sol
@@ -331,13 +331,7 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, ReentrancyGuardUpgradeable
             tokenReceived = order.outputToken;
 
             // Distribute tokens: exact amount to recipient, surplus to solver
-            order.outputToken.safeTransfer(order.recipient, order.outputAmount);
-
-            uint256 surplus = amountReceived - order.outputAmount;
-            if (surplus > 0) {
-                address solver = order.options.solver == address(0) ? msg.sender : order.options.solver;
-                order.outputToken.safeTransfer(solver, surplus);
-            }
+            order.outputToken.distributeWithSurplus(order.recipient, order.outputAmount, order.options.solver, amountReceived);
         } else {
             // Cross-chain: convert to preferred token for cross-chain transfer
             amountReceived = ExecutionUtils.observeBalChg(hook.hookAddress, hook.instructions, hook.preferredToken);
@@ -535,13 +529,7 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, ReentrancyGuardUpgradeable
             if (amountReceived < order.outputAmount) revert InsufficientSrcHookOutput(order.outputAmount, amountReceived);
 
             // Distribute tokens: exact amount to recipient, surplus to solver
-            order.outputToken.safeTransfer(order.recipient, order.outputAmount);
-
-            uint256 surplus = amountReceived - order.outputAmount;
-            if (surplus > 0) {
-                address solver = order.options.solver == address(0) ? msg.sender : order.options.solver;
-                order.outputToken.safeTransfer(solver, surplus);
-            }
+            order.outputToken.distributeWithSurplus(order.recipient, order.outputAmount, order.options.solver, amountReceived);
 
             emit SrcHookExecuted(orderId, order.inputToken, order.outputToken, order.inputAmount, amountReceived);
 

--- a/contracts/libraries/internal/TokenUtils.sol
+++ b/contracts/libraries/internal/TokenUtils.sol
@@ -74,4 +74,27 @@ library TokenUtils {
             if (IERC20(token).balanceOf(address(this)) < amount) revert InsufficientContractBalance(token);
         }
     }
+
+    /**
+     * @notice Distributes tokens to recipient and surplus to solver
+     * @param token The token to distribute
+     * @param recipient The primary recipient
+     * @param recipientAmount The exact amount for recipient
+     * @param solver The solver to receive surplus (or address(0) for msg.sender)
+     * @param totalAmount The total amount received
+     */
+    function distributeWithSurplus(
+        address token,
+        address recipient,
+        uint256 recipientAmount,
+        address solver,
+        uint256 totalAmount
+    ) internal {
+        safeTransfer(token, recipient, recipientAmount);
+        uint256 surplus = totalAmount - recipientAmount;
+        if (surplus > 0) {
+            address surplusRecipient = solver == address(0) ? msg.sender : solver;
+            safeTransfer(token, surplusRecipient, surplus);
+        }
+    }
 }


### PR DESCRIPTION
Add `distributeWithSurplus()` to TokenUtils, saving 88 bytes (margin: 34→122 bytes)