### PR TITLE
WIP/dedicated swap functions

### DIFF
--- a/contracts/Aori.sol
+++ b/contracts/Aori.sol
@@ -263,8 +263,7 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, ReentrancyGuardUpgradeable
     /**
      * @notice Deposits tokens to the contract with a hook call for token conversion
      * @dev Executes a hook call for token conversion before deposit processing.
-     *      For single-chain swaps, immediately settles and transfers tokens to recipient.
-     *      For cross-chain swaps, locks converted tokens for later settlement.
+     *      For cross-chain orders only - use swap() for single-chain atomic swaps.
      * @param order The order details
      * @param signature The user's EIP712 signature over the order
      * @param hook The pre-hook configuration for token conversion
@@ -275,36 +274,26 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, ReentrancyGuardUpgradeable
         SrcHook calldata hook
     ) external nonReentrant whenNotPaused onlySolver {
         if (order.inputToken.isNativeToken()) revert UseDepositNativeForNativeTokens();
+
         bytes32 orderId = order.validateDeposit(signature, _hashOrder712(order), ENDPOINT_ID, this.orderStatus, this.isSupportedChain);
 
-        // Execute hook to convert input tokens to preferred/output tokens
+        // Execute hook to convert input tokens to preferred token
         (uint256 amountReceived, address tokenReceived) = _executeSrcHook(order, hook);
 
         emit SrcHookExecuted(orderId, order.inputToken, tokenReceived, order.inputAmount, amountReceived);
 
-        if (order.isSingleChainSwap()) {
-            // Single-chain: immediate settlement (tokens already transferred to recipient)
-            AoriStorageData storage $ = _getAoriStorage();
-            $.orders[orderId] = order;
-            $.orderStatus[orderId] = OrderStatus.Settled;
-            emit Deposit(orderId, order);
-            emit Fill(orderId, order);
-            emit Settle(orderId);
-        } else {
-            // Cross-chain: lock converted tokens for later settlement
-            _postDeposit(tokenReceived, amountReceived, order, orderId);
-        }
+        _postDeposit(tokenReceived, amountReceived, order, orderId);
     }
 
     /**
-     * @notice Executes a source hook to convert input tokens and handle distribution
-     * @dev Sends input tokens (native or ERC20) to hook, executes conversion, and handles token distribution.
-     *      For single-chain swaps: converts to output token and immediately distributes.
-     *      For cross-chain swaps: converts to preferred token for later cross-chain transfer.
+     * @notice Executes a source hook to convert input tokens to preferred token
+     * @dev Sends input tokens (native or ERC20) to hook, executes conversion to preferred token.
+     *      Works for both single-chain and cross-chain orders using deposit-then-fill flow.
+     *      For atomic single-chain swaps, use swap() with _executeSwap() instead.
      * @param order The order details
      * @param hook The source hook configuration
      * @return amountReceived The amount of tokens received from the hook
-     * @return tokenReceived The token address that was received
+     * @return tokenReceived The token address that was received (hook.preferredToken)
      */
     function _executeSrcHook(
         Order calldata order,
@@ -323,30 +312,13 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, ReentrancyGuardUpgradeable
             IERC20(order.inputToken).safeTransferFrom(order.offerer, hook.hookAddress, order.inputAmount);
         }
 
-        if (order.isSingleChainSwap()) {
-            // Single-chain: convert to final output token and distribute immediately
-            amountReceived = ExecutionUtils.observeBalChg(hook.hookAddress, hook.instructions, order.outputToken);
+        // Cross-chain: convert to preferred token for cross-chain transfer
+        amountReceived = ExecutionUtils.observeBalChg(hook.hookAddress, hook.instructions, hook.preferredToken);
 
-            if (amountReceived < order.outputAmount) revert InsufficientSrcHookOutput(order.outputAmount, amountReceived);
-            tokenReceived = order.outputToken;
-
-            // Distribute tokens: exact amount to recipient, surplus to solver
-            order.outputToken.safeTransfer(order.recipient, order.outputAmount);
-
-            uint256 surplus = amountReceived - order.outputAmount;
-            if (surplus > 0) {
-                address solver = order.options.solver == address(0) ? msg.sender : order.options.solver;
-                order.outputToken.safeTransfer(solver, surplus);
-            }
-        } else {
-            // Cross-chain: convert to preferred token for cross-chain transfer
-            amountReceived = ExecutionUtils.observeBalChg(hook.hookAddress, hook.instructions, hook.preferredToken);
-
-            if (amountReceived < hook.minPreferredTokenAmountOut) {
-                revert InsufficientSrcHookOutput(hook.minPreferredTokenAmountOut, amountReceived);
-            }
-            tokenReceived = hook.preferredToken;
+        if (amountReceived < hook.minPreferredTokenAmountOut) {
+            revert InsufficientSrcHookOutput(hook.minPreferredTokenAmountOut, amountReceived);
         }
+        tokenReceived = hook.preferredToken;
     }
 
     /**
@@ -390,9 +362,7 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, ReentrancyGuardUpgradeable
     /**
      * @notice Deposits native tokens to the contract with a hook call for token conversion
      * @dev User calls this directly and sends their own ETH via msg.value.
-     *      Executes a hook call for token conversion before deposit processing.
-     *      For single-chain swaps, immediately settles and transfers tokens to recipient.
-     *      For cross-chain swaps, locks converted tokens for later settlement.
+     *      For cross-chain orders only - use swapNative() for single-chain atomic swaps.
      * @param order The order details (must specify NATIVE_TOKEN as inputToken)
      * @param hook The pre-hook configuration for token conversion
      */
@@ -406,23 +376,12 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, ReentrancyGuardUpgradeable
 
         bytes32 orderId = order.validateDepositNoSig(ENDPOINT_ID, this.orderStatus, this.isSupportedChain);
 
-        // Execute hook to convert native tokens to preferred/output tokens
+        // Execute hook to convert native tokens to preferred token
         (uint256 amountReceived, address tokenReceived) = _executeSrcHook(order, hook);
 
         emit SrcHookExecuted(orderId, order.inputToken, tokenReceived, order.inputAmount, amountReceived);
 
-        if (order.isSingleChainSwap()) {
-            // Single-chain: immediate settlement (tokens already transferred to recipient)
-            AoriStorageData storage $ = _getAoriStorage();
-            $.orders[orderId] = order;
-            $.orderStatus[orderId] = OrderStatus.Settled;
-            emit Deposit(orderId, order);
-            emit Fill(orderId, order);
-            emit Settle(orderId);
-        } else {
-            // Cross-chain: lock converted tokens for later settlement
-            _postDeposit(tokenReceived, amountReceived, order, orderId);
-        }
+        _postDeposit(tokenReceived, amountReceived, order, orderId);
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -456,8 +415,7 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, ReentrancyGuardUpgradeable
     /**
      * @notice Deposits tokens using Permit2 with source hook for token conversion
      * @dev Tokens are transferred directly to the hook via Permit2, then hook converts them.
-     *      For single-chain swaps, immediately settles and transfers tokens to recipient.
-     *      For cross-chain swaps, locks converted tokens for later settlement.
+     *      For cross-chain orders only - use swapWithPermit2() for single-chain atomic swaps.
      * @param order The order to deposit (witness data)
      * @param hook Source hook for token conversion
      * @param nonce Permit2 nonce for replay protection
@@ -479,44 +437,149 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, ReentrancyGuardUpgradeable
 
         Permit2Lib.executeTransfer(order, hook.hookAddress, nonce, deadline, signature);
 
-        // Execute hook conversion (tokens already at hook address)
-        if (order.isSingleChainSwap()) {
-            // Single-chain: convert to final output token and distribute immediately
-            uint256 amountReceived = ExecutionUtils.observeBalChg(hook.hookAddress, hook.instructions, order.outputToken);
+        // Execute hook conversion - convert to preferred token
+        uint256 amountReceived = ExecutionUtils.observeBalChg(hook.hookAddress, hook.instructions, hook.preferredToken);
 
-            if (amountReceived < order.outputAmount) revert InsufficientSrcHookOutput(order.outputAmount, amountReceived);
-
-            // Distribute tokens: exact amount to recipient, surplus to solver
-            order.outputToken.safeTransfer(order.recipient, order.outputAmount);
-
-            uint256 surplus = amountReceived - order.outputAmount;
-            if (surplus > 0) {
-                address solver = order.options.solver == address(0) ? msg.sender : order.options.solver;
-                order.outputToken.safeTransfer(solver, surplus);
-            }
-
-            emit SrcHookExecuted(orderId, order.inputToken, order.outputToken, order.inputAmount, amountReceived);
-
-            // Single-chain: immediate settlement
-            AoriStorageData storage $ = _getAoriStorage();
-            $.orders[orderId] = order;
-            $.orderStatus[orderId] = OrderStatus.Settled;
-            emit Deposit(orderId, order);
-            emit Fill(orderId, order);
-            emit Settle(orderId);
-        } else {
-            // Cross-chain: convert to preferred token for cross-chain transfer
-            uint256 amountReceived = ExecutionUtils.observeBalChg(hook.hookAddress, hook.instructions, hook.preferredToken);
-
-            if (amountReceived < hook.minPreferredTokenAmountOut) {
-                revert InsufficientSrcHookOutput(hook.minPreferredTokenAmountOut, amountReceived);
-            }
-
-            emit SrcHookExecuted(orderId, order.inputToken, hook.preferredToken, order.inputAmount, amountReceived);
-
-            // Cross-chain: lock converted tokens for later settlement
-            _postDeposit(hook.preferredToken, amountReceived, order, orderId);
+        if (amountReceived < hook.minPreferredTokenAmountOut) {
+            revert InsufficientSrcHookOutput(hook.minPreferredTokenAmountOut, amountReceived);
         }
+
+        emit SrcHookExecuted(orderId, order.inputToken, hook.preferredToken, order.inputAmount, amountReceived);
+
+        _postDeposit(hook.preferredToken, amountReceived, order, orderId);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                       ATOMIC SWAPS                         */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /**
+     * @notice Executes an atomic single-chain swap via hook
+     * @dev Only for single-chain orders. Input tokens converted to output via hook.
+     * @param order The order details (srcEid must equal dstEid)
+     * @param signature User's EIP-712 signature
+     * @param hook The source hook for token conversion
+     */
+    function swap(
+        Order calldata order,
+        bytes calldata signature,
+        SrcHook calldata hook
+    ) external nonReentrant whenNotPaused onlySolver {
+        if (order.inputToken.isNativeToken()) revert UseDepositNativeForNativeTokens();
+        if (!order.isSingleChainSwap()) revert NotSingleChainOrder();
+
+        bytes32 orderId = order.validateDeposit(
+            signature,
+            _hashOrder712(order),
+            ENDPOINT_ID,
+            this.orderStatus,
+            this.isSupportedChain
+        );
+
+        hook.validateSrcHook(this.isAllowedHook);
+
+        IERC20(order.inputToken).safeTransferFrom(order.offerer, hook.hookAddress, order.inputAmount);
+
+        address solver = order.options.solver == address(0) ? msg.sender : order.options.solver;
+        _executeSwap(orderId, order, hook, solver);
+    }
+
+    /**
+     * @notice Executes an atomic single-chain swap with native token input
+     * @dev Offerer must be msg.sender. Native tokens sent to hook for conversion.
+     * @param order The order details (inputToken must be NATIVE_TOKEN)
+     * @param hook The source hook for token conversion
+     */
+    function swapNative(
+        Order calldata order,
+        SrcHook calldata hook
+    ) external payable nonReentrant whenNotPaused {
+        if (!order.inputToken.isNativeToken()) revert OrderMustSpecifyNativeToken();
+        if (msg.value != order.inputAmount) revert IncorrectNativeAmount(order.inputAmount, msg.value);
+        if (msg.sender != order.offerer) revert OnlyOffererCanDepositNativeTokens();
+        if (!order.isSingleChainSwap()) revert NotSingleChainOrder();
+
+        bytes32 orderId = order.validateDepositNoSig(ENDPOINT_ID, this.orderStatus, this.isSupportedChain);
+
+        hook.validateSrcHook(this.isAllowedHook);
+
+        (bool success,) = payable(hook.hookAddress).call{ value: order.inputAmount }("");
+        if (!success) revert NativeTransferFailed();
+
+        address solver = order.options.solver == address(0) ? msg.sender : order.options.solver;
+        _executeSwap(orderId, order, hook, solver);
+    }
+
+    /**
+     * @notice Executes an atomic single-chain swap using Permit2
+     * @dev Tokens transferred directly to hook via Permit2
+     * @param order The order details
+     * @param hook The source hook for token conversion
+     * @param nonce Permit2 nonce
+     * @param deadline Permit2 signature deadline
+     * @param signature User's Permit2 signature
+     */
+    function swapWithPermit2(
+        Order calldata order,
+        SrcHook calldata hook,
+        uint256 nonce,
+        uint256 deadline,
+        bytes calldata signature
+    ) external nonReentrant whenNotPaused onlySolver {
+        if (order.inputToken.isNativeToken()) revert UseSwapNativeForNativeTokens();
+        if (block.timestamp > deadline) revert Permit2SignatureExpired();
+        if (!order.isSingleChainSwap()) revert NotSingleChainOrder();
+
+        bytes32 orderId = order.validateDepositNoSig(ENDPOINT_ID, this.orderStatus, this.isSupportedChain);
+        hook.validateSrcHook(this.isAllowedHook);
+
+        Permit2Lib.executeTransfer(order, hook.hookAddress, nonce, deadline, signature);
+
+        address solver = order.options.solver == address(0) ? msg.sender : order.options.solver;
+        _executeSwap(orderId, order, hook, solver);
+    }
+
+    /**
+     * @notice Core swap execution logic shared by all swap variants
+     * @dev Executes hook, validates output, distributes tokens, updates state
+     * @param orderId The computed order hash
+     * @param order The order details
+     * @param hook The source hook for token conversion
+     * @param solver The solver address (for surplus distribution)
+     * @return amountReceived The amount of output tokens received from hook
+     */
+    function _executeSwap(
+        bytes32 orderId,
+        Order calldata order,
+        SrcHook calldata hook,
+        address solver
+    ) internal returns (uint256 amountReceived) {
+        AoriStorageData storage $ = _getAoriStorage();
+
+        // Execute hook - converts input to output
+        amountReceived = ExecutionUtils.observeBalChg(hook.hookAddress, hook.instructions, order.outputToken);
+
+        if (amountReceived < order.outputAmount) {
+            revert InsufficientSrcHookOutput(order.outputAmount, amountReceived);
+        }
+
+        // Calculate distribution
+        uint256 surplus = amountReceived - order.outputAmount;
+
+        // Transfer to recipient
+        order.outputToken.safeTransfer(order.recipient, order.outputAmount);
+
+        // Surplus to solver
+        if (surplus > 0) {
+            order.outputToken.safeTransfer(solver, surplus);
+        }
+
+        // Update state
+        $.orders[orderId] = order;
+        $.orderStatus[orderId] = OrderStatus.Settled;
+
+        // Emit event
+        emit Swap(orderId, order, amountReceived);
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/

--- a/contracts/Aori.sol
+++ b/contracts/Aori.sol
@@ -563,16 +563,8 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, ReentrancyGuardUpgradeable
             revert InsufficientSrcHookOutput(order.outputAmount, amountReceived);
         }
 
-        // Calculate distribution
-        uint256 surplus = amountReceived - order.outputAmount;
-
-        // Transfer to recipient
-        order.outputToken.safeTransfer(order.recipient, order.outputAmount);
-
-        // Surplus to solver
-        if (surplus > 0) {
-            order.outputToken.safeTransfer(solver, surplus);
-        }
+        // Distribute tokens: exact amount to recipient, surplus to solver
+        order.outputToken.distributeWithSurplus(order.recipient, order.outputAmount, solver, amountReceived);
 
         // Update state
         $.orders[orderId] = order;
@@ -627,8 +619,6 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, ReentrancyGuardUpgradeable
         uint256 amountReceived = _executeDstHook(order, hook);
         emit DstHookExecuted(orderId, hook.preferredToken, order.outputToken, hook.preferredDstInputAmount, amountReceived);
 
-        uint256 surplus = amountReceived - order.outputAmount;
-
         // Update contract state
         if (order.isSingleChainSwap()) {
             _settleSingleChainSwap(orderId, order, msg.sender);
@@ -636,11 +626,8 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, ReentrancyGuardUpgradeable
             _postFill(orderId, order);
         }
 
-        // Transfer tokens: exact amount to recipient, surplus to solver
-        order.outputToken.safeTransfer(order.recipient, order.outputAmount);
-        if (surplus > 0) {
-            order.outputToken.safeTransfer(msg.sender, surplus);
-        }
+        // Distribute tokens: exact amount to recipient, surplus to solver
+        order.outputToken.distributeWithSurplus(order.recipient, order.outputAmount, address(0), amountReceived);
     }
 
     /**

--- a/contracts/interfaces/IAori.sol
+++ b/contracts/interfaces/IAori.sol
@@ -183,4 +183,57 @@ interface IAori {
      * @param amountOut The amount of output tokens received from hook execution
      */
     event DstHookExecuted(bytes32 indexed orderId, address indexed tokenIn, address tokenOut, uint256 amountIn, uint256 amountOut);
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                       SWAP FUNCTIONS                        */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /**
+     * @notice Emitted when an atomic single-chain swap is executed
+     * @param orderId The unique order identifier
+     * @param order The order details
+     * @param amountReceived The amount of output tokens received from hook
+     */
+    event Swap(bytes32 indexed orderId, Order order, uint256 amountReceived);
+
+    /**
+     * @notice Execute atomic single-chain swap with ERC20 input
+     * @dev Only for single-chain orders (srcEid == dstEid). Input tokens converted to output via hook.
+     * @param order The order details
+     * @param signature User's EIP-712 signature
+     * @param hook The source hook for token conversion
+     */
+    function swap(
+        Order calldata order,
+        bytes calldata signature,
+        SrcHook calldata hook
+    ) external;
+
+    /**
+     * @notice Execute atomic single-chain swap with native token input
+     * @dev Offerer must be msg.sender. Native tokens sent to hook for conversion.
+     * @param order The order details (inputToken must be NATIVE_TOKEN)
+     * @param hook The source hook for token conversion
+     */
+    function swapNative(
+        Order calldata order,
+        SrcHook calldata hook
+    ) external payable;
+
+    /**
+     * @notice Execute atomic single-chain swap with Permit2
+     * @dev Tokens transferred directly to hook via Permit2
+     * @param order The order details
+     * @param hook The source hook for token conversion
+     * @param nonce Permit2 nonce
+     * @param deadline Permit2 signature deadline
+     * @param signature User's Permit2 signature
+     */
+    function swapWithPermit2(
+        Order calldata order,
+        SrcHook calldata hook,
+        uint256 nonce,
+        uint256 deadline,
+        bytes calldata signature
+    ) external;
 }

--- a/contracts/libraries/internal/BalanceUtils.sol
+++ b/contracts/libraries/internal/BalanceUtils.sol
@@ -84,22 +84,6 @@ library BalanceUtils {
     }
 
     /**
-     * @notice Unlocks all locked tokens into the unlocked balance
-     * @dev Moves the entire locked balance to unlocked
-     * @param balance The Balance struct reference
-     * @return amount The amount that was unlocked
-     */
-    /* forgefmt: disable-next-item */
-    function unlockAll(Balance storage balance) internal returns (uint128 amount) {
-        (uint128 locked, uint128 unlocked) = loadBalance(balance);
-        amount = locked;
-        unlocked += amount;
-        locked = 0;
-
-        storeBalance(balance, locked, unlocked);
-    }
-
-    /**
      * @notice Gets the unlocked balance amount
      * @param balance The Balance struct reference
      * @return The unlocked balance amount

--- a/contracts/types/AoriErrors.sol
+++ b/contracts/types/AoriErrors.sol
@@ -222,6 +222,16 @@ error InvalidUserAddress();
 error AmountMustBeGreaterThanZero();
 
 /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+/*                       SWAP ERRORS                          */
+/*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+/// @notice Thrown when swap() is called for a cross-chain order
+error NotSingleChainOrder();
+
+/// @notice Thrown when swapNative() should be used instead of swapWithPermit2
+error UseSwapNativeForNativeTokens();
+
+/*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
 /*                    PERIPHERY ERRORS                        */
 /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 

--- a/test/foundry/20_Balance.t.sol
+++ b/test/foundry/20_Balance.t.sol
@@ -15,13 +15,11 @@ pragma solidity 0.8.33;
  * 2. testRevert_LockMax - Tests overflow handling when locking maximum uint128 value
  * 3. testUnlock - Tests unlocking of previously locked tokens
  * 4. testRevert_UnlockInsufficientBalance - Tests revert when trying to unlock more than locked
- * 5. testUnlockAll - Tests unlocking all locked tokens at once
- * 6. testDecreaseLockedNoRevert - Tests non-reverting locked balance decrease
- * 7. testDecreaseLockedNoRevertUnderflow - Tests handling of underflow in non-reverting decrease
- * 8. testIncreaseUnlockedNoRevert - Tests non-reverting unlocked balance increase
- * 9. testIncreaseUnlockedNoRevertOverflow - Tests handling of overflow in non-reverting increase
- * 10. testComplexSequence - Tests a complex sequence of balance operations
- * 11. testGasUsage - Tests gas optimization of the balance operations
+ * 5. testDecreaseLockedNoRevert - Tests non-reverting locked balance decrease
+ * 6. testDecreaseLockedNoRevertUnderflow - Tests handling of underflow in non-reverting decrease
+ * 7. testIncreaseUnlockedNoRevert - Tests non-reverting unlocked balance increase
+ * 8. testIncreaseUnlockedNoRevertOverflow - Tests handling of overflow in non-reverting increase
+ * 9. testComplexSequence - Tests a complex sequence of balance operations
  *
  * Special notes:
  * - These tests focus on the Balance struct operations in isolation
@@ -104,20 +102,6 @@ contract BalanceUtilsTest is Test {
     }
 
     /**
-     * @notice Tests unlocking all locked tokens at once
-     */
-    function testUnlockAll() public {
-        uint128 amountToLock = 500;
-
-        balance.lock(amountToLock);
-        uint128 unlocked = balance.unlockAll();
-
-        assertEq(unlocked, amountToLock, "Should return unlocked amount");
-        assertEq(balance.getLocked(), 0, "Locked amount should be zero");
-        assertEq(balance.getUnlocked(), amountToLock, "Unlocked amount should increase by total locked");
-    }
-
-    /**
      * @notice Tests non-reverting locked balance decrease
      */
     function testDecreaseLockedNoRevert() public {
@@ -187,18 +171,13 @@ contract BalanceUtilsTest is Test {
         balance.lock(700);
         assertEq(balance.getLocked(), 1000, "Locked should increase to 1000");
 
-        // Unlock all
-        uint128 unlockedAmount = balance.unlockAll();
-        assertEq(unlockedAmount, 1000, "Should return 1000 as unlocked amount");
-        assertEq(balance.getLocked(), 0, "Locked should be 0");
-        assertEq(balance.getUnlocked(), 1200, "Unlocked should be 1200");
-
         // Test no-revert functions
-        bool success = balance.decreaseLockedNoRevert(100);
-        assertFalse(success, "Should fail when locked is 0");
+        bool success = balance.decreaseLockedNoRevert(1000);
+        assertTrue(success, "Should succeed");
+        assertEq(balance.getLocked(), 0, "Locked should be 0");
 
         success = balance.increaseUnlockedNoRevert(300);
         assertTrue(success, "Should succeed");
-        assertEq(balance.getUnlocked(), 1500, "Unlocked should increase to 1500");
+        assertEq(balance.getUnlocked(), 500, "Unlocked should increase to 500");
     }
 }

--- a/test/foundry/23_BalanceUtilsTests.t.sol
+++ b/test/foundry/23_BalanceUtilsTests.t.sol
@@ -37,10 +37,6 @@ contract BalanceWrapper {
         return balance.increaseUnlockedNoRevert(amount);
     }
 
-    function unlockAll() external returns (uint128) {
-        return balance.unlockAll();
-    }
-
     function getUnlocked() external view returns (uint128) {
         return balance.getUnlocked();
     }
@@ -295,36 +291,6 @@ contract BalanceUtilsTest is Test {
         assertFalse(success);
         assertEq(wrapper.getLocked(), 100); // Should remain unchanged
         assertEq(wrapper.getUnlocked(), MAX_UINT128); // Should remain unchanged
-    }
-
-    /// @dev Tests the unlockAll function
-    /// @notice Covers lines 105-111 in AoriUtils.sol
-    function test_unlockAll() public {
-        // Arrange
-        wrapper.setRawBalance(100, 50);
-
-        // Act
-        uint128 unlockedAmount = wrapper.unlockAll();
-
-        // Assert
-        assertEq(unlockedAmount, 100);
-        assertEq(wrapper.getLocked(), 0);
-        assertEq(wrapper.getUnlocked(), 150);
-    }
-
-    /// @dev Tests the unlockAll function with zero locked amount
-    /// @notice Covers lines 105-111 in AoriUtils.sol
-    function test_unlockAll_zeroLocked() public {
-        // Arrange
-        wrapper.setRawBalance(0, 50);
-
-        // Act
-        uint128 unlockedAmount = wrapper.unlockAll();
-
-        // Assert
-        assertEq(unlockedAmount, 0);
-        assertEq(wrapper.getLocked(), 0);
-        assertEq(wrapper.getUnlocked(), 50);
     }
 
     /// @dev Tests the getUnlocked function
@@ -586,13 +552,11 @@ contract BalanceUtilsTest is Test {
         assertTrue(decreaseSuccess); // locked = 100, unlocked = 200
         bool increaseSuccess = wrapper.increaseUnlockedNoRevert(700); // Should succeed
         assertTrue(increaseSuccess); // locked = 100, unlocked = 900
-        uint128 unlocked = wrapper.unlockAll(); // Should unlock 100
-        assertEq(unlocked, 100); // locked = 0, unlocked = 1000
 
         // Final state verification
         (uint128 finalLocked, uint128 finalUnlocked) = wrapper.loadBalance();
-        assertEq(finalLocked, 0);
-        assertEq(finalUnlocked, 1000);
+        assertEq(finalLocked, 100);
+        assertEq(finalUnlocked, 900);
     }
 
     /// @dev Tests the integration of the new validation functions with balance operations


### PR DESCRIPTION
# Dedicated functions for atomic swaps 

This PR abstracts single-chain atomic swaps into dedicated `swap()` functions, separating them from the deposit/fill/settle flow. This creates cleaner code paths and enables distinct fee models per flow.

---
Previously `isSingleChainSwap()` created scattered inline branching logic across multiple functions:

**1. `_executeSrcHook()` (lines 309-350)**
```solidity
if (order.isSingleChainSwap()) {
    // Single-chain: convert to output, distribute immediately
    amountReceived = ExecutionUtils.observeBalChg(..., order.outputToken);
    order.outputToken.safeTransfer(order.recipient, order.outputAmount);
    // surplus to solver
} else {
    // Cross-chain: convert to preferred token for later
    amountReceived = ExecutionUtils.observeBalChg(..., hook.preferredToken);
}
```

**2. `deposit(order, sig, hook)` (lines 272-297)**
```solidity
if (order.isSingleChainSwap()) {
    $.orders[orderId] = order;
    $.orderStatus[orderId] = OrderStatus.Settled;
    emit Deposit, Fill, Settle...
} else {
    _postDeposit(tokenReceived, amountReceived, order, orderId);
}
```

**3. `depositNative(order, hook)` (lines 399-426)**
Same branching pattern.

**4. `depositWithPermit2(order, hook, ...)` (lines 467-520)**
Same branching pattern.

This Is problematic as it creates code duplication, mixed semantics around deposit() functions and would lend complexity to features yet to be implemented such as fee distribution logic, order type conditionalization etc.

---

## New State

3 new dedicated `swap()` functions:

```solidity
/*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
/*                       SWAP FUNCTIONS                        */
/*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/

/**
 * @notice Execute atomic single-chain swap with ERC20 input
 */
function swap(
    Order calldata order,
    bytes calldata signature,
    SrcHook calldata hook
) external;

/**
 * @notice Execute atomic single-chain swap with native token input
 */
function swapNative(
    Order calldata order,
    SrcHook calldata hook
) external payable;

/**
 * @notice Execute atomic single-chain swap with Permit2
 */
function swapWithPermit2(
    Order calldata order,
    SrcHook calldata hook,
    uint256 nonce,
    uint256 deadline,
    bytes calldata signature
) external;
```

These functions wrap the internal helper `_executeSwap()`

```solidity
/**
 * @notice Core swap execution logic shared by all swap variants
 * @dev Executes hook, validates output, distributes tokens, updates state
 * @param orderId The computed order hash
 * @param order The order details
 * @param hook The source hook for token conversion
 * @param solver The solver address (for surplus distribution)
 * @return amountReceived The amount of output tokens received from hook
 */
function _executeSwap(
    bytes32 orderId,
    Order calldata order,
    SrcHook calldata hook,
    address solver
) internal returns (uint256 amountReceived) {
    AoriStorageData storage $ = _getAoriStorage();
    
    // Execute hook - converts input to output
    amountReceived = ExecutionUtils.observeBalChg(
        hook.hookAddress, 
        hook.instructions, 
        order.outputToken
    );
    
    if (amountReceived < order.outputAmount) {
        revert InsufficientHookOutput(order.outputAmount, amountReceived);
    }
    
    // Calculate distribution
    uint256 surplus = amountReceived - order.outputAmount;
    
    // Transfer to recipient
    order.outputToken.safeTransfer(order.recipient, order.outputAmount);
    
    // Surplus to solver
    if (surplus > 0) {
        order.outputToken.safeTransfer(solver, surplus);
    }
    
    // Update state
    $.orders[orderId] = order;
    $.orderStatus[orderId] = OrderStatus.Settled;
    
    // Emit events
    emit Swap(orderId, order, amountReceived);
}
```

### Clean Separation of Concerns

| Function | Purpose | Settlement | Fee Token |
|----------|---------|------------|-----------|
| `swap()` | Single-chain atomic | Immediate | outputToken |
| `deposit()` | Lock for later fill | At settle | inputToken |
| `fill()` | Provide output tokens | — | — |
| `settle()` | Release input to solver | Here | inputToken |

### Function Mapping

| Current | New |
|---------|-----|
| `deposit(order, sig, hook)` + single-chain | `swap(order, sig, hook)` |
| `depositNative(order, hook)` + single-chain | `swapNative(order, hook)` |
| `depositWithPermit2(order, hook, ...)` + single-chain | `swapWithPermit2(order, hook, ...)` |
| `deposit(order, sig, hook)` + cross-chain | `deposit(order, sig, hook)` (simplified) |

---

### Notes

1. Swap functions reuse existing `validateDeposit()` and `validateDepositNoSig()` from `ValidationUtils.sol`:

could consider renaming for semantic accuracy

2. Added `swap()` event for now, largely as a placeholder, need to think critically about event schemas in this context. Very much subject to change.
