### PR TITLE
slippage

### DIFF
--- a/contracts/Aori.sol
+++ b/contracts/Aori.sol
@@ -239,7 +239,6 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, ReentrancyGuardUpgradeable
     /* forgefmt: disable-next-item */
     function getMaxFillsPerSettle() external view returns (uint16) { return AoriAdminLib.getMaxFillsPerSettle(); }
 
-
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                         MODIFIERS                          */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
@@ -567,17 +566,24 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, ReentrancyGuardUpgradeable
         // Execute hook - converts input to output
         amountReceived = ExecutionUtils.observeBalChg(hook.hookAddress, hook.instructions, order.outputToken);
 
-        if (amountReceived < order.outputAmount) {
-            revert InsufficientSrcHookOutput(order.outputAmount, amountReceived);
+        // Calculate minimum acceptable output (returns outputAmount when slippageMbps = 0)
+        uint256 minOutput = (uint256(order.outputAmount) * (ValidationUtils.MBPS_DIVISOR - order.options.slippageMbps)) / ValidationUtils.MBPS_DIVISOR;
+
+        if (amountReceived < minOutput) {
+            revert SlippageExceeded(minOutput, amountReceived);
         }
 
-        // Calculate both fees
-        // Fee calculations use uint128 - safe because fee validations ensure totalFee <= outputAmount
-        uint128 protocolFee = uint128((uint256(order.outputAmount) * $.protocolFeeMbps) / ValidationUtils.MBPS_DIVISOR);
-        uint128 additionalFee = uint128((uint256(order.outputAmount) * order.options.feeMbps) / ValidationUtils.MBPS_DIVISOR);
+        // Fee basis: if slippageMbps > 0, recipient captures surplus so fee on actual; otherwise fee on signed amount
+        uint256 feeBasis = order.options.slippageMbps > 0 ? amountReceived : order.outputAmount;
+
+        // Fee calculations use uint128 - safe because fee validations ensure totalFee <= feeBasis
+        uint128 protocolFee = uint128((feeBasis * $.protocolFeeMbps) / ValidationUtils.MBPS_DIVISOR);
+        uint128 additionalFee = uint128((feeBasis * order.options.feeMbps) / ValidationUtils.MBPS_DIVISOR);
         uint128 totalFee = protocolFee + additionalFee;
-        uint128 recipientAmount = order.outputAmount - totalFee;
-        uint256 surplus = amountReceived - order.outputAmount;
+        uint128 recipientAmount = SafeCast.toUint128(feeBasis) - totalFee;
+
+        // Surplus: if slippageMbps = 0, solver gets surplus; if > 0, recipient already received it via feeBasis
+        uint256 surplus = order.options.slippageMbps > 0 ? 0 : amountReceived - order.outputAmount;
 
         // Recipient gets output minus fees (immediate transfer)
         order.outputToken.safeTransfer(order.recipient, recipientAmount);
@@ -599,7 +605,7 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, ReentrancyGuardUpgradeable
             $.balances[actualFeeRecipient][order.outputToken].unlocked += additionalFee;
         }
 
-        // Surplus accrues to solver
+        // Surplus accrues to solver (only when slippageMbps = 0)
         if (surplus > 0) {
             $.balances[solver][order.outputToken].unlocked += SafeCast.toUint128(surplus);
         }
@@ -657,6 +663,13 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, ReentrancyGuardUpgradeable
         uint256 amountReceived = _executeDstHook(order, hook);
         emit DstHookExecuted(orderId, hook.preferredToken, order.outputToken, hook.preferredDstInputAmount, amountReceived);
 
+        // Calculate and validate minimum output (returns outputAmount when slippageMbps = 0)
+        uint256 minOutput = (uint256(order.outputAmount) * (ValidationUtils.MBPS_DIVISOR - order.options.slippageMbps)) / ValidationUtils.MBPS_DIVISOR;
+
+        if (amountReceived < minOutput) {
+            revert SlippageExceeded(minOutput, amountReceived);
+        }
+
         // Update contract state
         if (order.isSingleChainSwap()) {
             _settleSingleChainSwap(orderId, order, msg.sender);
@@ -664,16 +677,20 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, ReentrancyGuardUpgradeable
             _postFill(orderId, order);
         }
 
-        // Transfer output to recipient, accrue surplus to solver
-        order.outputToken.safeTransfer(order.recipient, order.outputAmount);
-        uint256 surplus = amountReceived - order.outputAmount;
-        if (surplus > 0) {
+        // Determine who gets surplus: slippageMbps > 0 → recipient, slippageMbps = 0 → solver
+        uint256 recipientAmount = order.options.slippageMbps > 0 ? amountReceived : order.outputAmount;
+        order.outputToken.safeTransfer(order.recipient, recipientAmount);
+
+        // Surplus to solver only when slippageMbps = 0
+        if (order.options.slippageMbps == 0 && amountReceived > order.outputAmount) {
+            uint256 surplus = amountReceived - order.outputAmount;
             _getAoriStorage().balances[msg.sender][order.outputToken].unlocked += SafeCast.toUint128(surplus);
         }
     }
 
     /**
      * @notice Executes a destination hook and handles token conversion
+     * @dev Validation of output amount moved to caller for slippage-aware minOutput calculation
      * @param order The order details
      * @param hook The destination hook configuration
      * @return balChg The balance change observed from the hook execution
@@ -694,7 +711,7 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, ReentrancyGuardUpgradeable
         }
 
         balChg = ExecutionUtils.observeBalChg(hook.hookAddress, hook.instructions, order.outputToken);
-        if (balChg < order.outputAmount) revert InsufficientDstHookOutput(order.outputAmount, balChg);
+        // Output validation moved to caller for slippage-aware minOutput check
     }
 
     /**

--- a/contracts/types/AoriErrors.sol
+++ b/contracts/types/AoriErrors.sol
@@ -104,11 +104,6 @@ error NonZeroBalanceRequired();
 /// @param available The available locked balance
 error LockedBalanceDecreaseFailed(uint128 attempted, uint128 available);
 
-/// @notice Thrown when balance consistency check fails
-/// @param expected The expected balance
-/// @param actual The actual balance
-error BalanceInconsistency(uint256 expected, uint256 actual);
-
 /// @notice Thrown when contract doesn't have enough balance
 /// @param token The token address (NATIVE_TOKEN for native)
 error InsufficientContractBalance(address token);
@@ -133,11 +128,6 @@ error HookDecreasedContractBalance();
 /// @param expected The expected output amount
 /// @param received The actual amount received
 error InsufficientSrcHookOutput(uint256 expected, uint256 received);
-
-/// @notice Thrown when destination hook doesn't provide enough output tokens
-/// @param expected The expected output amount
-/// @param received The actual amount received
-error InsufficientDstHookOutput(uint256 expected, uint256 received);
 
 /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
 /*                      SOLVER ERRORS                         */

--- a/test/foundry/10_HookFailuresTest.t.sol
+++ b/test/foundry/10_HookFailuresTest.t.sol
@@ -86,7 +86,7 @@ contract HookFailuresTest is TestUtils {
         outputToken.approve(address(remoteAori), order.outputAmount);
 
         vm.prank(solver);
-        vm.expectRevert(abi.encodeWithSelector(InsufficientDstHookOutput.selector, order.outputAmount, 1e18));
+        vm.expectRevert(abi.encodeWithSelector(SlippageExceeded.selector, order.outputAmount, 1e18));
         remoteAori.fill(order, dstData);
     }
 

--- a/test/foundry/15_SecurityAndAdvancedEdgeCasesTest.t.sol
+++ b/test/foundry/15_SecurityAndAdvancedEdgeCasesTest.t.sol
@@ -390,7 +390,7 @@ contract SecurityAndAdvancedEdgeCasesTest is TestUtils {
         dstData.instructions = abi.encodeWithSelector(MockHook.handleHook.selector, address(outputToken), 1); // Will return much less than required
 
         vm.prank(solver);
-        vm.expectRevert(abi.encodeWithSelector(InsufficientDstHookOutput.selector, order.outputAmount, 1));
+        vm.expectRevert(abi.encodeWithSelector(SlippageExceeded.selector, order.outputAmount, 1));
         remoteAori.fill(order, dstData);
     }
 

--- a/test/foundry/6_FillFail.t.sol
+++ b/test/foundry/6_FillFail.t.sol
@@ -205,7 +205,7 @@ contract FillFailTest is TestUtils {
         vm.prank(solver);
         outputToken.approve(address(remoteAori), order.outputAmount);
 
-        vm.expectRevert(abi.encodeWithSelector(InsufficientDstHookOutput.selector, order.outputAmount, 0));
+        vm.expectRevert(abi.encodeWithSelector(SlippageExceeded.selector, order.outputAmount, 0));
         vm.prank(solver);
         remoteAori.fill(order, dstData);
     }

--- a/test/foundry/SC_ERC20ToNativeDstHook.t.sol
+++ b/test/foundry/SC_ERC20ToNativeDstHook.t.sol
@@ -635,7 +635,7 @@ contract SC_ERC20ToNativeDstHook_Test is TestUtils {
             )
         });
 
-        vm.expectRevert(abi.encodeWithSelector(InsufficientDstHookOutput.selector, OUTPUT_AMOUNT, OUTPUT_AMOUNT - 1));
+        vm.expectRevert(abi.encodeWithSelector(SlippageExceeded.selector, OUTPUT_AMOUNT, OUTPUT_AMOUNT - 1));
         vm.prank(solverSC);
         localAori.fill{ value: OUTPUT_AMOUNT }(order, dstHook);
     }


### PR DESCRIPTION
# Slippage / Market Order Implementation

## Overview

The `slippageMbps` field in `Options` determines **who captures price improvement** (surplus):

| `slippageMbps` | Order Type | Surplus Goes To | Minimum Output |
|----------------|-----------------|----------------|----------------|
| `0` | Limit | Solver | `outputAmount` (exact) |
| `> 0` | Market | Recipient | `outputAmount × (slippage %)` |

Fees are orthogonal to this—they're always deducted from whoever receives the output.

---

### Current Behavior (Limit Orders Only)

| Function | Output Validation | Fee Basis | Surplus |
|----------|-------------------|-----------|---------|
| `_executeSwap()` | `amountReceived >= outputAmount` | `outputAmount` | `amountReceived - outputAmount` → solver |
| `fill(Order)` | None (exact transfer) | N/A (fees at settlement) | None |
| `fill(Order, DstHook)` | `balChg >= outputAmount` | N/A (fees at settlement) | `balChg - outputAmount` → solver |
| `_settleOrder()` | None | `inputAmount` | N/A |

---

## Economic Model

### slippageMbps = 0: Solver Gets Surplus

```
User signs: outputAmount = 1000 DAI, slippageMbps = 0

Solver executes DEX trade, gets 1050 DAI
                    ↓
┌─────────────────────────────────────────────────┐
│  Validation:      1050 >= 1000 ✓                │
│  Recipient gets:  1000 DAI (minus fees)         │
│  Solver gets:       50 DAI (surplus)            │
└─────────────────────────────────────────────────┘
```

**Solver incentive:** Execution efficiency → surplus.

### slippageMbps > 0: Recipient Gets Surplus

```
User signs: outputAmount = 1000 DAI, slippageMbps = 5000 (5%)

minOutput = 1000 × (100000 - 5000) / 100000 = 950 DAI

Solver executes DEX trade, gets 980 DAI
                    ↓
┌─────────────────────────────────────────────────┐
│  Validation:      980 >= 950 ✓                  │
│  Recipient gets:  980 DAI (minus fees)          │
│  Solver gets:       0 DAI                       │
└─────────────────────────────────────────────────┘
```

**Solver incentive:** Fee (set `feeRecipient = address(0)` to route fee to solver).

---

## Minimum Output Calculation

```solidity
uint256 minOutput = (order.outputAmount * (MBPS_DIVISOR - order.options.slippageMbps)) / MBPS_DIVISOR;
```

---

## Implementation Changes

### 1. `_executeSwap()` (Atomic Swap Path)

**Current:**
```solidity
if (amountReceived < order.outputAmount) {
    revert InsufficientSrcHookOutput(order.outputAmount, amountReceived);
}

uint128 protocolFee = uint128((uint256(order.outputAmount) * $.protocolFeeMbps) / MBPS_DIVISOR);
uint128 additionalFee = uint128((uint256(order.outputAmount) * order.options.feeMbps) / MBPS_DIVISOR);
uint128 recipientAmount = order.outputAmount - totalFee;
uint256 surplus = amountReceived - order.outputAmount;
```

**After:**
```solidity
// Calculate minimum acceptable output (returns outputAmount when slippageMbps = 0)
uint256 minOutput = (order.outputAmount * (MBPS_DIVISOR - order.options.slippageMbps)) / MBPS_DIVISOR;

if (amountReceived < minOutput) {
    revert SlippageExceeded(minOutput, amountReceived);
}

// Fee basis: if slippage > 0, recipient captures surplus so fee on actual; otherwise fee on signed amount
uint256 feeBasis = order.options.slippageMbps > 0 ? amountReceived : order.outputAmount;

uint128 protocolFee = uint128((feeBasis * $.protocolFeeMbps) / MBPS_DIVISOR);
uint128 additionalFee = uint128((feeBasis * order.options.feeMbps) / MBPS_DIVISOR);
uint128 totalFee = protocolFee + additionalFee;

// Recipient gets feeBasis minus fees
uint128 recipientAmount = SafeCast.toUint128(feeBasis) - totalFee;

// Surplus: if slippageMbps = 0, solver gets surplus; if > 0, recipient already received it
uint256 surplus = order.options.slippageMbps > 0 ? 0 : amountReceived - order.outputAmount;
```

**Key changes:**
- Validation uses `minOutput` instead of `outputAmount`
- Error changes from `InsufficientSrcHookOutput` to `SlippageExceeded`
- Fee basis: `amountReceived` when slippage > 0, `outputAmount` when slippage = 0
- Recipient amount derived from `feeBasis - totalFee` (no separate ternary needed)
- Surplus: goes to solver when slippage = 0, goes to recipient (already in feeBasis) when slippage > 0

### 2. `fill(Order)` (Direct Fill - No Hook)

**No changes needed.**

The solver provides exactly `outputAmount` via direct transfer. There's no variable output, so the slippage field is simply unused:

- User signs with `slippageMbps > 0`: They'll accept as low as `minOutput`
- Solver provides exactly `outputAmount` (which is ≥ `minOutput` by definition)
- User gets `outputAmount`
- Order is satisfied

The slippage tolerance only becomes relevant when there's variable output (hooks). For direct fills, the solver commits to the exact signed amount.

### 3. `fill(Order, DstHook)` (Fill with Hook)

**Current:**
```solidity
uint256 amountReceived = _executeDstHook(order, hook);

order.outputToken.safeTransfer(order.recipient, order.outputAmount);
uint256 surplus = amountReceived - order.outputAmount;
if (surplus > 0) {
    $.balances[msg.sender][order.outputToken].unlocked += SafeCast.toUint128(surplus);
}
```

**After:**
```solidity
uint256 amountReceived = _executeDstHook(order, hook);

// Calculate and validate minimum output (returns outputAmount when slippageMbps = 0)
uint256 minOutput = (order.outputAmount * (MBPS_DIVISOR - order.options.slippageMbps)) / MBPS_DIVISOR;

if (amountReceived < minOutput) {
    revert SlippageExceeded(minOutput, amountReceived);
}

// Determine who gets surplus: slippageMbps > 0 → recipient, slippageMbps = 0 → solver
uint256 recipientAmount = order.options.slippageMbps > 0 ? amountReceived : order.outputAmount;
order.outputToken.safeTransfer(order.recipient, recipientAmount);

// Surplus to solver only when slippageMbps = 0
if (order.options.slippageMbps == 0 && amountReceived > order.outputAmount) {
    uint256 surplus = amountReceived - order.outputAmount;
    $.balances[msg.sender][order.outputToken].unlocked += SafeCast.toUint128(surplus);
}
```

**Key changes:**
- Validate `amountReceived >= minOutput`
- `slippageMbps > 0`: transfer full `amountReceived` to recipient (they capture surplus)
- `slippageMbps = 0`: transfer exact `outputAmount`, surplus to solver

### 4. `_executeDstHook()` (Hook Execution)

**Current:**
```solidity
balChg = ExecutionUtils.observeBalChg(hook.hookAddress, hook.instructions, order.outputToken);
if (balChg < order.outputAmount) revert InsufficientDstHookOutput(order.outputAmount, balChg);
```

**After:** Remove validation here, let caller handle it.

```solidity
balChg = ExecutionUtils.observeBalChg(hook.hookAddress, hook.instructions, order.outputToken);
// Validation moved to caller for order-type-aware minOutput calculation
```

**Alternative:** Pass minOutput as parameter (encapsulates validation but adds parameter).

### 5. Settlement Functions

**No changes required.** 

Settlement (`_settleOrder`, `_settleSingleChainSwap`) operates on `inputAmount`, which is fixed at deposit time. The market/limit distinction only affects the fill side (output distribution).

---

## Fee Basis by Path

| Path | Order Type | Fee Basis | Fee Token |
|------|------------|-----------|-----------|
| `swap()` | Limit | `outputAmount` | `outputToken` |
| `swap()` | Market | `amountReceived` (actual) | `outputToken` |
| `fill() → settle` | Limit | `inputAmount` | `inputToken` |
| `fill() → settle` | Market | `inputAmount` (unchanged) | `inputToken` |

On the fill→settle path, fee basis is always `inputAmount` regardless of order type. Only the output distribution changes.

---
    
## Events

Fee information is emitted with the settle event.

```solidity
event Settle(
        bytes32 indexed orderId,
        address indexed solver,
        uint256 solverUnlockedAmount,
        uint256 protocolFee,
        address feeRecipient,
        uint256 additionalFee
);
```

---

## Errors

```solidity
error SlippageExceeded(uint256 minimum, uint256 actual);  // Already defined
```

---

## Validation Helper (Optional)

Add to `ValidationUtils.sol` if reused in multiple places:

```solidity
/// @notice Calculates minimum acceptable output for an order
function getMinOutput(Order calldata order) internal pure returns (uint256) {
    return (order.outputAmount * (MBPS_DIVISOR - order.options.slippageMbps)) / MBPS_DIVISOR;
}
```

---

## Numerical Examples

### Example 1: slippageMbps = 0 via `swap()` Path

```
Order:
  outputAmount: 1000 DAI
  slippageMbps: 0
  feeMbps: 1000 (1%)
  protocolFeeMbps: 100 (0.1%)

Hook returns: 1050 DAI

Calculation:
  minOutput = 1000 DAI
  ✓ 1050 >= 1000
  
  feeBasis = outputAmount = 1000 DAI (slippageMbps = 0)
  protocolFee = 1000 × 100 / 100000 = 1 DAI
  additionalFee = 1000 × 1000 / 100000 = 10 DAI
  totalFee = 11 DAI
  
  recipientAmount = 1000 - 11 = 989 DAI
  surplus = 1050 - 1000 = 50 DAI → solver

Distribution:
  → Recipient: 989 DAI
  → pendingProtocolFees[DAI] += 1
  → feeRecipient.unlocked += 10
  → solver.unlocked += 50
```

### Example 2: slippageMbps > 0 via `swap()` Path

```
Order:
  outputAmount: 1000 DAI (reference)
  slippageMbps: 5000 (5%)
  feeMbps: 1000 (1%)
  protocolFeeMbps: 100 (0.1%)

Hook returns: 980 DAI

Calculation:
  minOutput = 1000 × (100000 - 5000) / 100000 = 950 DAI
  ✓ 980 >= 950
  
  feeBasis = amountReceived = 980 DAI (slippageMbps > 0)
  protocolFee = 980 × 100 / 100000 = 0.98 DAI
  additionalFee = 980 × 1000 / 100000 = 9.8 DAI
  totalFee = 10.78 DAI
  
  recipientAmount = 980 - 10.78 = 969.22 DAI (recipient gets surplus)

Distribution:
  → Recipient: 969.22 DAI
  → pendingProtocolFees[DAI] += 0.98
  → feeRecipient.unlocked += 9.8
  → solver: 0
```

### Example 3: Slippage Exceeded

```
Order:
  outputAmount: 1000 DAI
  slippageMbps: 5000 (5%)

Hook returns: 940 DAI

Validation:
  minOutput = 950 DAI
  ✗ 940 < 950
  → REVERT: SlippageExceeded(950, 940)
```

### Example 4: Cross-Chain with slippageMbps > 0

```
Order:
  inputAmount: 1000 USDC (Arbitrum)
  outputAmount: 990 DAI (Ethereum)
  slippageMbps: 3000 (3%)
  feeMbps: 500 (0.5%)

1. deposit() on Arbitrum
   └─ Lock 1000 USDC

2. fill(order, hook) on Ethereum
   └─ Hook returns 1020 DAI
   └─ minOutput = 990 × 97% = 960.3 DAI
   └─ ✓ 1020 >= 960.3
   └─ Recipient gets 1020 DAI (slippageMbps > 0 → recipient captures surplus)

3. settle() on Arbitrum
   └─ fee = 1000 × 500 / 100000 = 5 USDC (always based on inputAmount)
   └─ solver.unlocked += 995 USDC
   └─ feeRecipient.unlocked += 5 USDC

Final:
  → Recipient: 1020 DAI
  → Solver: 995 USDC
  → Fee recipient: 5 USDC
```

---

## Game Theory: Why Solvers Can't Manipulate slippageMbps

A solver might be tempted to modify `slippageMbps` when filling an order to capture surplus that should go to the recipient. However, this is cryptographically prevented:

### Order Hash Binding

```
orderId = keccak256(abi.encode(order))
```

The `orderId` includes ALL order fields, including `slippageMbps`. Any modification changes the hash.

### Attack Scenario (Fails)

```
1. User deposits on Arbitrum:
   Order: { outputAmount: 1000, slippageMbps: 5000, ... }
   orderId: 0xabc123...
   
2. Solver fills on Ethereum with MODIFIED order:
   Order: { outputAmount: 1000, slippageMbps: 0, ... }  ← Changed!
   orderId: 0xdef456...  ← Different hash!
   
3. Solver sends settlement message with 0xdef456...

4. Source chain looks up orders[0xdef456...]:
   → OrderStatus.Unknown (doesn't exist)
   → Settlement fails
   → Solver receives nothing
```

### Result

The solver forfeits repayment entirely. The user's funds remain locked until: **a.** another solver fills correctly, or, **b.** The order expires and is cancelled. Solvers have zero incentive to modify `slippageMbps`. Doing so guarantees they lose the fill opportunity entirely.

---

## Solver Economics

### When slippageMbps = 0: Surplus-Based Profit

```
Profit = amountReceived - outputAmount
```

Solver captures execution efficiency gains.

### When slippageMbps > 0: Fee-Based Compensation

Since surplus goes to recipient, solvers are compensated via fees:

```solidity
Options({
    feeMbps: 500,              // 0.5% fee
    feeRecipient: address(0),  // Routes fee to solver
    solver: 0xSolver,
    slippageMbps: 5000         // 5% slippage tolerance
})
```
