### PR TITLE
transient reentrancy guard, hook revert forwarding calculate fees helper

### DIFF
--- a/contracts/Aori.sol
+++ b/contracts/Aori.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.33;
 
 import { OAppUpgradeable, Origin, MessagingFee, MessagingReceipt } from "@layerzerolabs/oapp-evm-upgradeable/contracts/oapp/OAppUpgradeable.sol";
 import { PayloadType, PayloadUtils } from "./utils/PayloadUtils.sol";
-import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
 import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -55,7 +54,7 @@ import "./types/AoriTypes.sol";
  * facilitating peer to peer exchange from any token to any token.
  */
 
-contract Aori is IAori, AoriStorage, OAppUpgradeable, ReentrancyGuardUpgradeable, PausableUpgradeable, UUPSUpgradeable, EIP712 {
+contract Aori is IAori, AoriStorage, OAppUpgradeable, PausableUpgradeable, UUPSUpgradeable, EIP712 {
     using PayloadUtils for bytes32[];
     using PayloadUtils for bytes;
     using SafeERC20 for IERC20;
@@ -69,6 +68,28 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, ReentrancyGuardUpgradeable
 
     /// @notice Unique identifier for this endpoint in the LayerZero network
     uint32 public immutable ENDPOINT_ID;
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                  REENTRANCY GUARD (EIP-1153)                */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Transient storage slot for reentrancy guard. Uses EIP-1153 (TSTORE/TLOAD)
+    ///      which is cleared after each transaction. ~100 gas vs ~5000 gas for SSTORE.
+    uint256 private constant _REENTRANCY_GUARD_SLOT = 0x929eee149b4bd21268;
+
+    modifier nonReentrant() {
+        assembly {
+            if tload(_REENTRANCY_GUARD_SLOT) {
+                mstore(0, 0x3ee5aeb5) // ReentrancyGuardReentrantCall()
+                revert(0x1c, 0x04)
+            }
+            tstore(_REENTRANCY_GUARD_SLOT, 1)
+        }
+        _;
+        assembly {
+            tstore(_REENTRANCY_GUARD_SLOT, 0)
+        }
+    }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                       STORAGE GAP                          */
@@ -101,7 +122,6 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, ReentrancyGuardUpgradeable
         if (_owner == address(0)) revert InvalidOwner();
         __Ownable_init(_owner);
         __OApp_init(_owner);
-        __ReentrancyGuard_init();
         __Pausable_init();
         __UUPSUpgradeable_init();
 
@@ -665,7 +685,7 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, ReentrancyGuardUpgradeable
         bytes calldata payload,
         address,
         bytes calldata
-    ) internal override whenNotPaused {
+    ) internal override nonReentrant whenNotPaused {
         if (payload.length == 0) revert EmptyPayload();
 
         PayloadType msgType = payload.getType();

--- a/contracts/lib/AoriAtomicSwapLib.sol
+++ b/contracts/lib/AoriAtomicSwapLib.sol
@@ -66,11 +66,8 @@ library AoriAtomicSwapLib {
         // Fee basis: if slippageMbps > 0, recipient captures surplus so fee on actual; otherwise fee on signed amount
         uint256 feeBasis = order.options.slippageMbps > 0 ? amountReceived : order.outputAmount;
 
-        // Fee calculations use uint128 - safe because fee validations ensure totalFee <= feeBasis
-        uint128 protocolFee = uint128((feeBasis * $.protocolFeeMbps) / ValidationUtils.MBPS_DIVISOR);
-        uint128 additionalFee = uint128((feeBasis * order.options.feeMbps) / ValidationUtils.MBPS_DIVISOR);
-        uint128 totalFee = protocolFee + additionalFee;
-        uint128 recipientAmount = SafeCast.toUint128(feeBasis) - totalFee;
+        (uint128 protocolFee, uint128 additionalFee, uint128 recipientAmount) =
+            ValidationUtils.calculateFees(feeBasis, $.protocolFeeMbps, order.options.feeMbps);
 
         // Surplus: if slippageMbps = 0, solver gets surplus; if > 0, recipient already received it via feeBasis
         uint256 surplus = order.options.slippageMbps > 0 ? 0 : amountReceived - order.outputAmount;

--- a/contracts/lib/AoriSettleLib.sol
+++ b/contracts/lib/AoriSettleLib.sol
@@ -63,12 +63,8 @@ library AoriSettleLib {
     ) external {
         AoriStorageData storage $ = _getAoriStorage();
 
-        // Calculate both fees (order.inputAmount is the locked amount, already correct for srcHook)
-        // Fee calculations use uint128 - safe because fee validations ensure totalFee <= inputAmount
-        uint128 protocolFee = uint128((uint256(order.inputAmount) * $.protocolFeeMbps) / ValidationUtils.MBPS_DIVISOR);
-        uint128 additionalFee = uint128((uint256(order.inputAmount) * order.options.feeMbps) / ValidationUtils.MBPS_DIVISOR);
-        uint128 totalFee = protocolFee + additionalFee;
-        uint128 solverAmount = order.inputAmount - totalFee;
+        (uint128 protocolFee, uint128 additionalFee, uint128 solverAmount) =
+            ValidationUtils.calculateFees(order.inputAmount, $.protocolFeeMbps, order.options.feeMbps);
 
         // Decrease offerer's locked balance
         $.balances[order.offerer][order.inputToken].locked -= order.inputAmount;
@@ -139,12 +135,8 @@ library AoriSettleLib {
             return; // Skip non-active orders
         }
 
-        // Calculate both fees (order.inputAmount is the locked amount, already correct for srcHook)
-        // Fee calculations use uint128 - safe because fee validations ensure totalFee <= inputAmount
-        uint128 protocolFee = uint128((uint256(order.inputAmount) * $.protocolFeeMbps) / ValidationUtils.MBPS_DIVISOR);
-        uint128 additionalFee = uint128((uint256(order.inputAmount) * order.options.feeMbps) / ValidationUtils.MBPS_DIVISOR);
-        uint128 totalFee = protocolFee + additionalFee;
-        uint128 fillerAmount = order.inputAmount - totalFee;
+        (uint128 protocolFee, uint128 additionalFee, uint128 fillerAmount) =
+            ValidationUtils.calculateFees(order.inputAmount, $.protocolFeeMbps, order.options.feeMbps);
 
         address feeRecipient = order.options.feeRecipient == address(0) 
             ? filler 

--- a/contracts/types/AoriErrors.sol
+++ b/contracts/types/AoriErrors.sol
@@ -119,7 +119,8 @@ error MissingHook();
 error InvalidHookAddress();
 
 /// @notice Thrown when hook call fails
-error HookCallFailed();
+/// @param reason The revert data returned by the hook
+error HookCallFailed(bytes reason);
 
 /// @notice Thrown when hook decreases contract balance
 error HookDecreasedContractBalance();

--- a/contracts/utils/HookUtils.sol
+++ b/contracts/utils/HookUtils.sol
@@ -26,8 +26,8 @@ library HookUtils {
         uint256 minAmount
     ) internal returns (uint256 amountReceived) {
         uint256 balBefore = TokenUtils.balanceOf(outputToken, address(this));
-        (bool success,) = target.call(data);
-        if (!success) revert HookCallFailed();
+        (bool success, bytes memory reason) = target.call(data);
+        if (!success) revert HookCallFailed(reason);
         uint256 balAfter = TokenUtils.balanceOf(outputToken, address(this));
 
         if (balAfter < balBefore) revert HookDecreasedContractBalance();

--- a/contracts/utils/ValidationUtils.sol
+++ b/contracts/utils/ValidationUtils.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.33;
 
 import { SignatureCheckerLib } from "solady/src/utils/SignatureCheckerLib.sol";
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import { Order, OrderStatus } from "../types/AoriTypes.sol";
 import { TokenUtils } from "./TokenUtils.sol";
 import "../types/AoriErrors.sol";
@@ -233,5 +234,24 @@ library ValidationUtils {
     ) internal view {
         if (hookAddress == address(0)) revert MissingHook();
         if (!isAllowedHook(hookAddress)) revert InvalidHookAddress();
+    }
+
+    /**
+     * @notice Calculates protocol fee, additional fee, and net amount from a basis amount
+     * @param basisAmount The amount to calculate fees on
+     * @param protocolFeeMbps Protocol fee rate in millibasis points
+     * @param additionalFeeMbps Additional fee rate in millibasis points
+     * @return protocolFee The protocol fee amount
+     * @return additionalFee The additional fee amount
+     * @return netAmount The basis amount minus both fees
+     */
+    function calculateFees(
+        uint256 basisAmount,
+        uint16 protocolFeeMbps,
+        uint16 additionalFeeMbps
+    ) internal pure returns (uint128 protocolFee, uint128 additionalFee, uint128 netAmount) {
+        protocolFee = uint128((basisAmount * protocolFeeMbps) / MBPS_DIVISOR);
+        additionalFee = uint128((basisAmount * additionalFeeMbps) / MBPS_DIVISOR);
+        netAmount = SafeCast.toUint128(basisAmount) - protocolFee - additionalFee;
     }
 }

--- a/test/foundry/10_HookFailuresTest.t.sol
+++ b/test/foundry/10_HookFailuresTest.t.sol
@@ -62,7 +62,7 @@ contract HookFailuresTest is TestUtils {
         outputToken.approve(address(remoteAori), order.outputAmount);
 
         vm.prank(solver);
-        vm.expectRevert(HookCallFailed.selector);
+        vm.expectRevert(abi.encodeWithSelector(HookCallFailed.selector, abi.encodeWithSignature("Error(string)", "Hook deliberately failed")));
         remoteAori.fill(order, dstData);
     }
 

--- a/test/foundry/26_ExecutionUtilTests.t.sol
+++ b/test/foundry/26_ExecutionUtilTests.t.sol
@@ -190,7 +190,7 @@ contract HookUtilsTest is Test {
         bytes memory callData = abi.encodeWithSelector(ExecutionMockHook.revertingFunction.selector);
 
         // Act & Assert
-        vm.expectRevert(HookCallFailed.selector);
+        vm.expectRevert(abi.encodeWithSelector(HookCallFailed.selector, abi.encodeWithSignature("Error(string)", "Reverting as requested")));
         wrapper.observeBalanceChange(address(mockHook), callData, address(token));
     }
 

--- a/test/foundry/9_ValidationFailure.t.sol
+++ b/test/foundry/9_ValidationFailure.t.sol
@@ -210,7 +210,7 @@ contract ValidationFailuresTest is TestUtils {
         outputToken.approve(address(remoteAori), order.outputAmount);
 
         vm.prank(solver);
-        vm.expectRevert(HookCallFailed.selector);
+        vm.expectRevert(abi.encodeWithSelector(HookCallFailed.selector, abi.encodeWithSignature("Error(string)", "Hook deliberately failed")));
         remoteAori.fill(order, dstData);
     }
 }


### PR DESCRIPTION
  HIGH-1: Transient storage reentrancy guard + _lzReceive protection                                                                                                   
  - Removed ReentrancyGuardUpgradeable inheritance (safe for UUPS — uses ERC-7201 namespaced storage, no layout shift)                                                 
  - Added custom nonReentrant modifier using EIP-1153 transient storage (~100 gas vs ~5000 gas for SSTORE)                                                             
  - Added nonReentrant to _lzReceive, closing the reentrancy gap on cross-chain cancellation/settlement paths                                                          
  - Removed __ReentrancyGuard_init() from initializer (transient storage auto-clears per transaction)                                                                
                                                                                                                                                                       
  HIGH-2: Hook revert reason forwarding                                                                                                                                
  - Changed error HookCallFailed() → error HookCallFailed(bytes reason) in AoriErrors.sol                                                                              
  - Updated HookUtils.executeHook to capture and forward return data from failed hook calls
  - Updated 3 test expectations to match new error encoding

  MEDIUM-2: Fee calculation dedup
  - Added ValidationUtils.calculateFees(basisAmount, protocolFeeMbps, additionalFeeMbps) returning (protocolFee, additionalFee, netAmount)
  - Replaced 3 duplicate fee calculations in AoriSettleLib.settleSingleChainSwap, AoriSettleLib._settleOrder, and AoriAtomicSwapLib.executeSwap
  - Standardized on SafeCast.toUint128 for the net amount conversion across all paths