### PR TITLE
Bump solc to 0.8.34

### DIFF
--- a/contracts/Aori.sol
+++ b/contracts/Aori.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 import { OAppUpgradeable, Origin, MessagingFee, MessagingReceipt } from "@layerzerolabs/oapp-evm-upgradeable/contracts/oapp/OAppUpgradeable.sol";
 import { PayloadType, PayloadUtils } from "./utils/PayloadUtils.sol";

--- a/contracts/AoriLens.sol
+++ b/contracts/AoriLens.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 import { Order } from "./types/AoriTypes.sol";
 

--- a/contracts/interfaces/IAori.sol
+++ b/contracts/interfaces/IAori.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 import { MessagingFee } from "@layerzerolabs/oapp-evm/contracts/oapp/OApp.sol";
 import { Order, OrderStatus, SrcHook, DstHook } from "../types/AoriTypes.sol";

--- a/contracts/lib/AoriAdminLib.sol
+++ b/contracts/lib/AoriAdminLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/contracts/lib/AoriAtomicSwapLib.sol
+++ b/contracts/lib/AoriAtomicSwapLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import { Order, OrderStatus, SrcHook } from "../types/AoriTypes.sol";

--- a/contracts/lib/AoriCancelLib.sol
+++ b/contracts/lib/AoriCancelLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 import { Order, OrderStatus } from "../types/AoriTypes.sol";
 import "../types/AoriErrors.sol";

--- a/contracts/lib/AoriSettleLib.sol
+++ b/contracts/lib/AoriSettleLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 import { Order, OrderStatus, Balance } from "../types/AoriTypes.sol";
 import "../types/AoriErrors.sol";

--- a/contracts/proxy/AoriProxy.sol
+++ b/contracts/proxy/AoriProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 

--- a/contracts/storage/AoriStorage.sol
+++ b/contracts/storage/AoriStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 import { Order, OrderStatus, Balance } from "../types/AoriTypes.sol";
 

--- a/contracts/types/AoriErrors.sol
+++ b/contracts/types/AoriErrors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 import { OrderStatus } from "./AoriTypes.sol";
 

--- a/contracts/types/AoriTypes.sol
+++ b/contracts/types/AoriTypes.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
 /*                            ORDER                           */

--- a/contracts/utils/BalanceUtils.sol
+++ b/contracts/utils/BalanceUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 import { Balance } from "../types/AoriTypes.sol";
 import "../types/AoriErrors.sol";

--- a/contracts/utils/HookUtils.sol
+++ b/contracts/utils/HookUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 import "../types/AoriErrors.sol";
 import { TokenUtils } from "./TokenUtils.sol";

--- a/contracts/utils/PayloadUtils.sol
+++ b/contracts/utils/PayloadUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 import "../types/AoriErrors.sol";
 

--- a/contracts/utils/Permit2Lib.sol
+++ b/contracts/utils/Permit2Lib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 import { ISignatureTransfer } from "@permit2/src/interfaces/ISignatureTransfer.sol";
 import { Order, Options } from "../types/AoriTypes.sol";

--- a/contracts/utils/TokenUtils.sol
+++ b/contracts/utils/TokenUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/contracts/utils/ValidationUtils.sol
+++ b/contracts/utils/ValidationUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 import { SignatureCheckerLib } from "solady/src/utils/SignatureCheckerLib.sol";
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,5 +1,5 @@
 [profile.default]
-solc-version = '0.8.33'
+solc-version = '0.8.34'
 src = 'contracts'
 out = 'out'
 test = 'test/foundry'

--- a/script/BaseScript.sol
+++ b/script/BaseScript.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 import "forge-std/Script.sol";
 import { Aori } from "../contracts/Aori.sol";

--- a/script/ConfigurePeers.s.sol
+++ b/script/ConfigurePeers.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 import "./BaseScript.sol";
 

--- a/script/DeployMultichain.s.sol
+++ b/script/DeployMultichain.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 import "./BaseScript.sol";
 

--- a/script/UpgradeAori.s.sol
+++ b/script/UpgradeAori.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 import "./BaseScript.sol";
 

--- a/test/Mock/ExecutionMockHook.sol
+++ b/test/Mock/ExecutionMockHook.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/test/Mock/MockAttacker.sol
+++ b/test/Mock/MockAttacker.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 import "../../contracts/interfaces/IAori.sol";
 import "../../contracts/Aori.sol";

--- a/test/Mock/MockERC20.sol
+++ b/test/Mock/MockERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/test/Mock/MockFeeOnTransferToken.sol
+++ b/test/Mock/MockFeeOnTransferToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 import "../Mock/MockERC20.sol";
 

--- a/test/Mock/MockHook.sol
+++ b/test/Mock/MockHook.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/test/Mock/MockHook2.sol
+++ b/test/Mock/MockHook2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/test/Mock/MockRevertingToken.sol
+++ b/test/Mock/MockRevertingToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 import "../Mock/MockERC20.sol";
 

--- a/test/foundry/10_HookFailuresTest.t.sol
+++ b/test/foundry/10_HookFailuresTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * HookFailuresTest - Tests various hook-related failure conditions in the Aori contract

--- a/test/foundry/11_MessageFormatFailures.t.sol
+++ b/test/foundry/11_MessageFormatFailures.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * MessageFormatFailuresTest - Tests failures related to message formats in the Aori cross-chain protocol

--- a/test/foundry/12_PausedTests.t.sol
+++ b/test/foundry/12_PausedTests.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * PausedTests - Tests administrative functions for pausing and emergency operations

--- a/test/foundry/13_CrossChainAndExclusivityTests.t.sol
+++ b/test/foundry/13_CrossChainAndExclusivityTests.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * CrossChainAndWhitelistTests - Tests cross-chain functionality and solver whitelist features

--- a/test/foundry/14_ExtremeOrderParametersTest.t.sol
+++ b/test/foundry/14_ExtremeOrderParametersTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * ExtremeOrderParametersTest - Tests extreme edge cases for order parameters in the Aori contract

--- a/test/foundry/15_SecurityAndAdvancedEdgeCasesTest.t.sol
+++ b/test/foundry/15_SecurityAndAdvancedEdgeCasesTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * SecurityAndAdvancedEdgeCasesTest - Tests for security features and advanced edge cases in the Aori protocol

--- a/test/foundry/16_HookWhitelistTest.t.sol
+++ b/test/foundry/16_HookWhitelistTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * @title HookWhitelistTest

--- a/test/foundry/17_TestCrossChainCancelAndSettle.t.sol
+++ b/test/foundry/17_TestCrossChainCancelAndSettle.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * @title CrossChainCancelAndSettleTest

--- a/test/foundry/18_QuoteTest.t.sol
+++ b/test/foundry/18_QuoteTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * @title QuoteTest

--- a/test/foundry/19_EdgeCases.t.sol
+++ b/test/foundry/19_EdgeCases.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * @title EdgeCasesTest

--- a/test/foundry/1_SingleOrder.t.sol
+++ b/test/foundry/1_SingleOrder.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * SingleOrderSuccessTest - Tests the full cross-chain flow with token conversion via hooks

--- a/test/foundry/20_Balance.t.sol
+++ b/test/foundry/20_Balance.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * @title BalanceUtilsTest

--- a/test/foundry/21_OrderIdConsistencyTest.t.sol
+++ b/test/foundry/21_OrderIdConsistencyTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * OrderIdConsistencyTest - Tests that the orderId emitted in events matches the hash calculated in _validateDeposit

--- a/test/foundry/22_HashVerificationTest.t.sol
+++ b/test/foundry/22_HashVerificationTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * HashVerificationTest - Generates reference hash values for cross-language testing

--- a/test/foundry/24_PayloadTesting.t.sol
+++ b/test/foundry/24_PayloadTesting.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * PayloadPackingUnpackingTest - Comprehensive tests for payload packing and unpacking utilities in AoriUtils.sol

--- a/test/foundry/26_ExecutionUtilTests.t.sol
+++ b/test/foundry/26_ExecutionUtilTests.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * HookUtilsTest - Tests for the HookUtils library

--- a/test/foundry/28_singleChainHookTests.t.sol
+++ b/test/foundry/28_singleChainHookTests.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * SingleChainHookTest - Tests single-chain swaps with hooks in the Aori contract

--- a/test/foundry/29_singleChainSwapTests.t.sol
+++ b/test/foundry/29_singleChainSwapTests.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * SingleChainSwapTests - Comprehensive tests for single-chain swap pathways

--- a/test/foundry/2_MultiOrder.t.sol
+++ b/test/foundry/2_MultiOrder.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * MultiOrderSuccessTest - Tests the full cross-chain flow for multiple orders with token conversion via hooks

--- a/test/foundry/30_supportedChain.t.sol
+++ b/test/foundry/30_supportedChain.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";

--- a/test/foundry/31_MessagingReceipt.t.sol
+++ b/test/foundry/31_MessagingReceipt.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 import "forge-std/Test.sol";
 import { IAori } from "../../contracts/interfaces/IAori.sol";

--- a/test/foundry/32_EmergencyTests.t.sol
+++ b/test/foundry/32_EmergencyTests.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * EmergencyTests - Comprehensive tests for all emergency functions

--- a/test/foundry/33_ManagementTests.t.sol
+++ b/test/foundry/33_ManagementTests.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 import "forge-std/Test.sol";
 import "../../contracts/Aori.sol";

--- a/test/foundry/34_NativeTokenTests.t.sol
+++ b/test/foundry/34_NativeTokenTests.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * @title Native Token Tests

--- a/test/foundry/35_Permit2Deposit.t.sol
+++ b/test/foundry/35_Permit2Deposit.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 import { Order, OrderStatus, SrcHook, DstHook, Balance, Options } from "../../contracts/types/AoriTypes.sol";
 import "./TestUtils.sol";

--- a/test/foundry/36_Upgrade.t.sol
+++ b/test/foundry/36_Upgrade.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * UpgradeTests - Tests for UUPS upgradeability of Aori

--- a/test/foundry/37_AoriLensTests.t.sol
+++ b/test/foundry/37_AoriLensTests.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * AoriLensTests - Tests for the AoriLens view contract

--- a/test/foundry/3_CancellationTests.t.sol
+++ b/test/foundry/3_CancellationTests.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * CancellationTests - Comprehensive tests for all order cancellation scenarios

--- a/test/foundry/4_Deposit.t.sol
+++ b/test/foundry/4_Deposit.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 import { Order, OrderStatus, SrcHook, DstHook, Balance } from "../../contracts/types/AoriTypes.sol";
 import { IAori } from "../../contracts/Aori.sol";

--- a/test/foundry/5_WithdrawTests.t.sol
+++ b/test/foundry/5_WithdrawTests.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * WithdrawTests - Comprehensive tests for the unified withdraw function

--- a/test/foundry/6_FillFail.t.sol
+++ b/test/foundry/6_FillFail.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * FillFailTest - Tests various failure conditions for the fill functionality in the Aori contract

--- a/test/foundry/7_SettlementTests.t.sol
+++ b/test/foundry/7_SettlementTests.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * SettlementTests - Tests for settlement functionality and array manipulation in the Aori protocol

--- a/test/foundry/8_DepositFail.t.sol
+++ b/test/foundry/8_DepositFail.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * DepositFailTest - Tests failure conditions for the deposit functionality in the Aori contract

--- a/test/foundry/9_ValidationFailure.t.sol
+++ b/test/foundry/9_ValidationFailure.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * ValidationFailuresTest - Tests various validation failure conditions in the Aori contract

--- a/test/foundry/CC_ERC20ToNativeDstHook.t.sol
+++ b/test/foundry/CC_ERC20ToNativeDstHook.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * @title End-to-End Test: Cross-Chain ERC20 → Native with DstHook

--- a/test/foundry/CC_ERC20ToNativeHook.t.sol
+++ b/test/foundry/CC_ERC20ToNativeHook.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * @title End-to-End Test: Cross-Chain ERC20 (with srcHook) → Native (with dstHook)

--- a/test/foundry/CC_ERC20ToNativeNoHook.t.sol
+++ b/test/foundry/CC_ERC20ToNativeNoHook.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * @title End-to-End Test: Cross-Chain ERC20 → Native without Hooks

--- a/test/foundry/CC_ERC20ToNativeSrcHook.t.sol
+++ b/test/foundry/CC_ERC20ToNativeSrcHook.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * @title End-to-End Test: Cross-Chain ERC20 → Native with SrcHook (No DstHook)

--- a/test/foundry/CC_NativeHookToDirectFill.t.sol
+++ b/test/foundry/CC_NativeHookToDirectFill.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * @title End-to-End Test: Cross-Chain Native + SrcHook → Direct Fill (No DstHook)

--- a/test/foundry/CC_NativeHookToHookFill.t.sol
+++ b/test/foundry/CC_NativeHookToHookFill.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * @title End-to-End Test: Cross-Chain Native + SrcHook → Fill with DstHook

--- a/test/foundry/CC_NativeToERC20NoHook.t.sol
+++ b/test/foundry/CC_NativeToERC20NoHook.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * @title End-to-End Test: Cross-Chain Native → ERC20 without Hooks

--- a/test/foundry/CC_NativeToERC20dstHook.t.sol
+++ b/test/foundry/CC_NativeToERC20dstHook.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * @title End-to-End Test: Cross-Chain Native → ERC20 with Destination Hook

--- a/test/foundry/CC_NativeToNativeHook.t.sol
+++ b/test/foundry/CC_NativeToNativeHook.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * @title End-to-End Test: Cross-Chain Native → Native with DstHook (1:1 Case)

--- a/test/foundry/CC_NativeToNativeNoHook.t.sol
+++ b/test/foundry/CC_NativeToNativeNoHook.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * @title End-to-End Test: Cross-Chain Native → Native with Direct Fill (No Hook)

--- a/test/foundry/GasReport.t.sol
+++ b/test/foundry/GasReport.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 import "forge-std/Test.sol";
 import { Aori, IAori } from "../../contracts/Aori.sol";

--- a/test/foundry/SC_ERC20ToNativeDstHook.t.sol
+++ b/test/foundry/SC_ERC20ToNativeDstHook.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * @title End-to-End Test: Single-Chain ERC20 Deposit → Native with DstHook

--- a/test/foundry/SC_ERC20ToNativeHook.t.sol
+++ b/test/foundry/SC_ERC20ToNativeHook.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * @title End-to-End Test: Single-Chain ERC20 → Native with SrcHook

--- a/test/foundry/SC_ERC20ToNativeSrcHook.t.sol
+++ b/test/foundry/SC_ERC20ToNativeSrcHook.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * @title End-to-End Test: Single-Chain ERC20 → Native with SrcHook (Atomic Settlement)

--- a/test/foundry/SC_NativeHookAtomicSwap.t.sol
+++ b/test/foundry/SC_NativeHookAtomicSwap.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * @title End-to-End Test: Single-Chain Native Deposit with SrcHook (Atomic Settlement)

--- a/test/foundry/SC_NativeToERC20Hook.t.sol
+++ b/test/foundry/SC_NativeToERC20Hook.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * @title End-to-End Test: Single-Chain Native → ERC20 with DstHook

--- a/test/foundry/SC_NativeToERC20NoHook.t.sol
+++ b/test/foundry/SC_NativeToERC20NoHook.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * @title End-to-End Test: Single-Chain Native Deposit → ERC20 (No Hooks)

--- a/test/foundry/TestUtils.sol
+++ b/test/foundry/TestUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.33;
+pragma solidity 0.8.34;
 
 /**
  * TestUtils - Common test utilities for Aori contract tests


### PR DESCRIPTION
## Summary
- Bumps Solidity compiler version from 0.8.33 to 0.8.34 across all 81 contract, test, and script files
- Updates `foundry.toml` `solc-version` to match
- Addresses `TSTORE` bug fix in the 0.8.34 release