### PR TITLE
fixed tests

### DIFF
--- a/test/foundry/28_singleChainHookTests.t.sol
+++ b/test/foundry/28_singleChainHookTests.t.sol
@@ -207,28 +207,33 @@ contract SingleChainHookTest is TestUtils {
             instructions: hookData
         });
 
-        // Execute deposit with hook
-        vm.prank(solver);
-        // Atomic single-chain SrcHook emits: SrcHookExecuted, Deposit, Fill, Settle
-        // Using try/catch to handle potential validation errors
-        try localAori.deposit(order, signature, hook) {
-            // Test passed
-            // Verify token transfers - similar to what we would do in a normal test
-            uint256 recipientBalance = outputToken.balanceOf(recipient);
-            assertEq(recipientBalance, outputAmount, "Recipient should receive exact output amount");
+        // Capture pre-deposit balances
+        uint256 initialSolverBalance = outputToken.balanceOf(solver);
+        uint256 expectedSurplus = extraOutputAmount - outputAmount;
 
-            // Check that solver received the surplus
-            uint256 expectedSurplus = extraOutputAmount - outputAmount;
-            uint256 solverBalance = outputToken.balanceOf(solver);
-            assertGe(solverBalance, expectedSurplus, "Solver should receive surplus tokens");
-        } catch (bytes memory reason) {
-            // If validation error occurs, we consider the test passed for the expected behavior
-            assertEq(
-                keccak256(reason),
-                keccak256(abi.encodeWithSignature("Error(string)", "Inconsistent offerer balance")),
-                "Expected 'Inconsistent offerer balance' error"
-            );
-        }
+        // Execute deposit with hook (atomic single-chain SrcHook: SrcHookExecuted, Deposit, Fill, Settle)
+        vm.prank(solver);
+        localAori.deposit(order, signature, hook);
+
+        // Verify recipient received exact output amount
+        assertEq(outputToken.balanceOf(recipient), outputAmount, "Recipient should receive exact output amount");
+
+        // Solver wallet balance should be unchanged (surplus goes to unlocked balance, not wallet)
+        assertEq(outputToken.balanceOf(solver), initialSolverBalance, "Solver wallet balance should not change from surplus");
+
+        // Surplus should be in solver's unlocked balance within the contract
+        assertEq(
+            localLens.getUnlockedBalances(solver, address(outputToken)),
+            expectedSurplus,
+            "Solver should receive surplus in unlocked balance"
+        );
+
+        // Verify order is settled atomically
+        assertEq(
+            uint8(localAori.orderStatus(orderId)),
+            uint8(OrderStatus.Settled),
+            "Order should be settled atomically"
+        );
     }
 
     /**
@@ -414,6 +419,4 @@ contract SingleChainHookTest is TestUtils {
         localAori.deposit(order, signature, hook);
     }
 
-    // Import events for testing
-    event Settle(bytes32 indexed orderId);
 }

--- a/test/foundry/29_singleChainSwapTests.t.sol
+++ b/test/foundry/29_singleChainSwapTests.t.sol
@@ -675,7 +675,8 @@ contract SingleChainSwapTests is TestUtils {
 
         // Verify solver received the surplus
         uint256 expectedSurplus = extraOutputAmount - OUTPUT_AMOUNT;
-        assertEq(outputToken.balanceOf(solver), initialSolverBalance + expectedSurplus, "Solver should receive surplus tokens");
+        assertEq(outputToken.balanceOf(solver), initialSolverBalance, "Solver external balance should not change from surplus");
+        assertEq(localLens.getUnlockedBalances(solver, address(outputToken)), expectedSurplus, "Solver should receive surplus tokens in unlocked balance");
     }
 
     // =========================================================================

--- a/test/foundry/31_MessagingReceipt.t.sol
+++ b/test/foundry/31_MessagingReceipt.t.sol
@@ -13,10 +13,6 @@ import { MessagingReceipt, MessagingFee } from "@layerzerolabs/oapp-evm/contract
  * @notice Tests the capturing and emitting of MessagingReceipt information in events
  */
 contract MessagingReceiptTest is TestUtils {
-    // Test events matching IAori event signatures
-    event SettleSent(uint32 indexed srcEid, address indexed filler, bytes payload, bytes32 guid, uint64 nonce, uint256 fee);
-    event CancelSent(bytes32 indexed orderId, bytes32 guid, uint64 nonce, uint256 fee);
-
     // Mock values for testing
     bytes32 constant TEST_GUID = bytes32(uint256(0x123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0));
     uint64 constant TEST_NONCE = 12345678;

--- a/test/foundry/4_Deposit.t.sol
+++ b/test/foundry/4_Deposit.t.sol
@@ -424,8 +424,8 @@ contract DepositTests is TestUtils {
         inputToken.approve(address(localAori), order.inputAmount);
 
         vm.prank(solver);
-        vm.expectEmit(true, false, false, true);
-        emit Deposit(orderId, order);
+        vm.expectEmit(true, true, false, true);
+        emit IAori.Deposit(orderId, order, address(0), 0);
         localAori.deposit(order, signature);
     }
 
@@ -515,11 +515,4 @@ contract DepositTests is TestUtils {
         });
     }
 
-    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
-    /*                           EVENTS                           */
-    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
-
-    event Deposit(bytes32 indexed orderId, Order order);
-    event SrcHookExecuted(bytes32 indexed orderId, address indexed tokenIn, address tokenOut, uint256 amountIn, uint256 amountOut);
-    event Settle(bytes32 indexed orderId);
 }

--- a/test/foundry/5_WithdrawTests.t.sol
+++ b/test/foundry/5_WithdrawTests.t.sol
@@ -59,8 +59,6 @@ contract WithdrawTests is TestUtils {
     // Counter to make orders unique
     uint256 private orderCounter;
 
-    // Events for testing
-    event Withdraw(address indexed holder, address indexed token, uint256 amount);
 
     function setUp() public override {
         super.setUp();
@@ -297,7 +295,7 @@ contract WithdrawTests is TestUtils {
 
         // Act & Assert
         vm.expectEmit(true, true, false, true);
-        emit Withdraw(solver, address(outputToken), expectedAmount);
+        emit IAori.Withdraw(solver, address(outputToken), expectedAmount);
 
         vm.prank(solver);
         localAori.withdraw(address(outputToken), 0);
@@ -310,7 +308,7 @@ contract WithdrawTests is TestUtils {
     function testWithdrawEventEmission_PartialWithdrawal() public {
         // Act & Assert - use solver
         vm.expectEmit(true, true, false, true);
-        emit Withdraw(solver, address(outputToken), PARTIAL_AMOUNT);
+        emit IAori.Withdraw(solver, address(outputToken), PARTIAL_AMOUNT);
 
         vm.prank(solver);
         localAori.withdraw(address(outputToken), PARTIAL_AMOUNT);

--- a/test/foundry/CC_ERC20ToNativeDstHook.t.sol
+++ b/test/foundry/CC_ERC20ToNativeDstHook.t.sol
@@ -303,14 +303,20 @@ contract CC_ERC20ToNativeDstHook is TestUtils {
             "Solver preferred token balance not reduced by fill"
         );
         assertEq(userDest.balance, preFillUserNative + OUTPUT_AMOUNT, "User did not receive the expected native tokens");
-        assertEq(solverDest.balance, preFillSolverNative + EXPECTED_SURPLUS, "Solver did not receive the expected surplus");
+        assertEq(solverDest.balance, preFillSolverNative, "Solver wallet native balance should be unchanged");
 
-        // The hook sends HOOK_OUTPUT to the contract, then the contract sends OUTPUT_AMOUNT to user and EXPECTED_SURPLUS to solver
-        // Net effect: contract balance should remain the same (receives HOOK_OUTPUT, sends HOOK_OUTPUT)
+        // Surplus goes to solver's unlocked balance in contract, not direct wallet transfer
+        assertEq(
+            remoteLens.getUnlockedBalances(solverDest, NATIVE_TOKEN),
+            EXPECTED_SURPLUS,
+            "Solver should receive surplus in unlocked balance"
+        );
+
+        // Contract holds the surplus in solver's unlocked balance
         assertEq(
             address(remoteAori).balance,
-            preFillContractNative,
-            "Contract balance should remain the same (receives from hook, sends to user+solver)"
+            preFillContractNative + EXPECTED_SURPLUS,
+            "Contract should hold surplus for solver's unlocked balance"
         );
 
         // Verify order status

--- a/test/foundry/CC_ERC20ToNativeHook.t.sol
+++ b/test/foundry/CC_ERC20ToNativeHook.t.sol
@@ -337,8 +337,14 @@ contract CC_ERC20ToNativeHook is TestUtils {
             preFillSolverDstPreferred - DST_PREFERRED_INPUT,
             "Solver should spend dstPreferred input amount"
         );
+        assertEq(solverDest.balance, preFillSolverNative, "Solver wallet native balance should be unchanged");
 
-        assertEq(solverDest.balance, preFillSolverNative + expectedSurplus, "Solver should receive surplus from hook conversion");
+        // Surplus goes to solver's unlocked balance in contract, not direct wallet transfer
+        assertEq(
+            remoteLens.getUnlockedBalances(solverDest, NATIVE_TOKEN),
+            expectedSurplus,
+            "Solver should receive surplus in unlocked balance"
+        );
 
         // Verify order status
         assertTrue(remoteAori.orderStatus(localAori.hash(order)) == OrderStatus.Filled, "Order should be Filled");
@@ -566,10 +572,17 @@ contract CC_ERC20ToNativeHook is TestUtils {
         assertEq(solverSrcPrefNetChange, int256(uint256(SRC_PREFERRED_OUTPUT)), "Solver should have gained srcPreferred tokens");
         assertEq(solverDstPrefNetChange, -int256(uint256(DST_PREFERRED_INPUT)), "Solver should have paid dstPreferred tokens");
 
-        // Calculate expected surplus from dstHook conversion (6 decimals -> 18 decimals scaling)
+        // Solver wallet native balance should be unchanged (surplus goes to unlocked balance)
+        assertEq(solverNativeNetChange, 0, "Solver wallet native balance should be unchanged");
+
+        // Surplus goes to solver's unlocked balance in remote contract, not wallet
         uint256 expectedDstHookOutput = DST_PREFERRED_INPUT * 1e12; // Scale from 6 to 18 decimals
         uint256 expectedSurplus = expectedDstHookOutput - OUTPUT_AMOUNT;
-        assertEq(solverNativeNetChange, int256(expectedSurplus), "Solver should have received expected surplus");
+        assertEq(
+            remoteLens.getUnlockedBalances(solverDest, NATIVE_TOKEN),
+            expectedSurplus,
+            "Solver should have received expected surplus in unlocked balance"
+        );
 
         console.log("");
         console.log("All assertions passed! Cross-chain ERC20 to Native swap (with dual hooks) successful.");

--- a/test/foundry/CC_NativeToERC20dstHook.t.sol
+++ b/test/foundry/CC_NativeToERC20dstHook.t.sol
@@ -275,18 +275,20 @@ contract CC_NativeToERC20DstHook is TestUtils {
         assertEq(outputToken.balanceOf(userDest), preFillUserOutputTokens + OUTPUT_AMOUNT, "User should receive exact output amount");
 
         assertEq(inputToken.balanceOf(solverDest), preFillSolverInputTokens - PREFERRED_INPUT, "Solver should spend preferred input amount");
+        assertEq(outputToken.balanceOf(solverDest), preFillSolverOutputTokens, "Solver wallet output token balance should be unchanged");
 
+        // Surplus goes to solver's unlocked balance in remote contract
         assertEq(
-            outputToken.balanceOf(solverDest),
-            preFillSolverOutputTokens + expectedSurplus,
-            "Solver should receive surplus from hook conversion"
+            remoteLens.getUnlockedBalances(solverDest, address(outputToken)),
+            expectedSurplus,
+            "Solver should receive surplus in unlocked balance"
         );
 
-        // Contract should not hold any tokens after hook execution
+        // Contract holds surplus tokens as solver's unlocked balance
         assertEq(
             outputToken.balanceOf(address(remoteAori)),
-            preFillContractOutputTokens,
-            "Contract should not hold output tokens after hook fill"
+            preFillContractOutputTokens + expectedSurplus,
+            "Contract should hold surplus output tokens as solver unlocked balance"
         );
 
         // Verify order status
@@ -506,11 +508,16 @@ contract CC_NativeToERC20DstHook is TestUtils {
         // Solver should have gained INPUT_AMOUNT ETH, paid PREFERRED_INPUT preferred tokens, and gained surplus
         assertEq(solverSourceNetChange, int256(uint256(INPUT_AMOUNT)), "Solver should have gained input ETH");
         assertEq(solverDestInputNetChange, -int256(uint256(PREFERRED_INPUT)), "Solver should have paid preferred tokens");
+        assertEq(solverDestOutputNetChange, 0, "Solver wallet output token balance should be unchanged");
 
-        // Calculate expected surplus from hook conversion (1:1 rate)
+        // Surplus goes to solver's unlocked balance in remote contract
         uint256 expectedHookOutput = PREFERRED_INPUT; // 1:1 conversion
         uint256 expectedSurplus = expectedHookOutput - OUTPUT_AMOUNT;
-        assertEq(solverDestOutputNetChange, int256(expectedSurplus), "Solver should have received expected surplus");
+        assertEq(
+            remoteLens.getUnlockedBalances(solverDest, address(outputToken)),
+            expectedSurplus,
+            "Solver should have received expected surplus in unlocked balance"
+        );
 
         console.log("");
         console.log("All assertions passed! Cross-chain Native to ERC20 swap (with destination hook) successful.");

--- a/test/foundry/CC_NativeToNativeHook.t.sol
+++ b/test/foundry/CC_NativeToNativeHook.t.sol
@@ -263,14 +263,19 @@ contract CC_NativeToNativeHook is TestUtils {
             "Solver preferred token balance not reduced by fill"
         );
         assertEq(userDest.balance, preFillUserNative + OUTPUT_AMOUNT, "User did not receive the expected native tokens");
-        assertEq(solverDest.balance, preFillSolverNative + EXPECTED_SURPLUS, "Solver did not receive the expected surplus");
+        assertEq(solverDest.balance, preFillSolverNative, "Solver wallet balance should not change (surplus goes to unlocked balance)");
+        assertEq(
+            remoteLens.getUnlockedBalances(solverDest, NATIVE_TOKEN),
+            EXPECTED_SURPLUS,
+            "Solver should receive surplus in unlocked native balance"
+        );
 
-        // The hook sends HOOK_OUTPUT to the contract, then the contract sends OUTPUT_AMOUNT to user and EXPECTED_SURPLUS to solver
-        // Net effect: contract balance should remain the same (receives HOOK_OUTPUT, sends HOOK_OUTPUT)
+        // The hook sends HOOK_OUTPUT to the contract, then the contract sends OUTPUT_AMOUNT to user
+        // Surplus stays in contract as solver's unlocked balance
         assertEq(
             address(remoteAori).balance,
-            preFillContractNative,
-            "Contract balance should remain the same (receives from hook, sends to user+solver)"
+            preFillContractNative + EXPECTED_SURPLUS,
+            "Contract balance should increase by surplus (held as solver unlocked balance)"
         );
 
         // Verify order status

--- a/test/foundry/SC_ERC20ToNativeDstHook.t.sol
+++ b/test/foundry/SC_ERC20ToNativeDstHook.t.sol
@@ -312,9 +312,17 @@ contract SC_ERC20ToNativeDstHook_Test is TestUtils {
         // Contract should still hold the tokens (they're in solver's unlocked balance)
         assertEq(inputToken.balanceOf(address(localAori)), INPUT_AMOUNT, "Contract should hold tokens in solver's unlocked balance");
 
-        // Verify the solver's net cost equals the order output amount (they effectively "bought" the tokens for 1 ETH)
-        uint256 expectedSolverBalance = 5 ether - OUTPUT_AMOUNT; // Started with 5 ETH, net cost should be 1 ETH
-        assertEq(solverSC.balance, expectedSolverBalance, "Solver should have net cost equal to order output amount");
+        // Solver sent DST_HOOK_INPUT to hook, surplus goes to unlocked balance
+        // Wallet: 5 ETH - DST_HOOK_INPUT = 3.8 ETH
+        uint256 expectedSolverBalance = 5 ether - DST_HOOK_INPUT;
+        assertEq(solverSC.balance, expectedSolverBalance, "Solver wallet should reflect hook input payment");
+
+        // Surplus in unlocked balance
+        assertEq(
+            localLens.getUnlockedBalances(solverSC, NATIVE_TOKEN),
+            EXPECTED_SURPLUS,
+            "Solver should have surplus in unlocked native balance"
+        );
 
         console.log("[PASS] All assertions passed!");
         console.log("[SURPLUS] Surplus of", (DST_HOOK_OUTPUT - OUTPUT_AMOUNT) / 1e18, "ETH was correctly distributed to solver");
@@ -412,10 +420,19 @@ contract SC_ERC20ToNativeDstHook_Test is TestUtils {
 
         assertEq(userReceived, OUTPUT_AMOUNT, string(abi.encodePacked(scenarioName, ": User should receive output amount")));
 
-        // Calculate expected net change: surplus - hook input (can be negative)
-        int256 expectedNetChange = int256(uint256(expectedSurplus)) - int256(uint256(hookInput));
+        // Solver wallet net change is just the hook input payment (surplus goes to unlocked balance)
+        int256 expectedWalletChange = -int256(uint256(hookInput));
         assertEq(
-            solverNetChange, expectedNetChange, string(abi.encodePacked(scenarioName, ": Solver net change should be surplus minus input"))
+            solverNetChange,
+            expectedWalletChange,
+            string(abi.encodePacked(scenarioName, ": Solver wallet change should reflect hook input payment"))
+        );
+
+        // Surplus goes to unlocked balance
+        assertEq(
+            localLens.getUnlockedBalances(testSolver, NATIVE_TOKEN),
+            expectedSurplus,
+            string(abi.encodePacked(scenarioName, ": Solver should have surplus in unlocked balance"))
         );
 
         assertTrue(

--- a/test/foundry/SC_ERC20ToNativeHook.t.sol
+++ b/test/foundry/SC_ERC20ToNativeHook.t.sol
@@ -178,7 +178,12 @@ contract SC_ERC20ToNativeHook_Test is TestUtils {
         // Verify token transfers
         assertEq(inputToken.balanceOf(userSC), initialUserTokens - INPUT_AMOUNT, "User should spend input tokens");
         assertEq(userSC.balance, initialUserNative + OUTPUT_AMOUNT, "User should receive native tokens");
-        assertEq(solverSC.balance, initialSolverNative + EXPECTED_SURPLUS, "Solver should receive surplus native tokens");
+        // Surplus goes to solver's unlocked balance in contract
+        assertEq(
+            localLens.getUnlockedBalances(solverSC, NATIVE_TOKEN),
+            EXPECTED_SURPLUS,
+            "Solver should receive surplus in unlocked balance"
+        );
 
         // Verify order status is Settled (atomic settlement for single-chain with hook)
         assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Settled, "Order should be Settled");
@@ -437,7 +442,11 @@ contract SC_ERC20ToNativeHook_Test is TestUtils {
 
         // Verify correct amounts
         assertEq(userSC.balance, initialUserNative + customOutputAmount, "User should receive custom output amount");
-        assertEq(solverSC.balance, initialSolverNative + (customHookOutput - customOutputAmount), "Solver should receive surplus");
+        assertEq(
+            localLens.getUnlockedBalances(solverSC, NATIVE_TOKEN),
+            customHookOutput - customOutputAmount,
+            "Solver should receive surplus in unlocked balance"
+        );
     }
 
     /**
@@ -454,7 +463,11 @@ contract SC_ERC20ToNativeHook_Test is TestUtils {
         // Verify no locked balances remain (atomic settlement)
         // For single-chain swaps with deposit hooks, no balance accounting is used
         assertEq(localLens.getLockedBalances(userSC, address(inputToken)), 0, "User should have no locked balance after atomic settlement");
-        assertEq(localLens.getUnlockedBalances(solverSC, NATIVE_TOKEN), 0, "Solver should have no unlocked balance for deposit hook swaps");
+        assertEq(
+            localLens.getUnlockedBalances(solverSC, NATIVE_TOKEN),
+            EXPECTED_SURPLUS,
+            "Solver should have surplus in unlocked balance"
+        );
 
         // Verify tokens were transferred directly (not through balance accounting)
         // User should have received native tokens directly

--- a/test/foundry/SC_ERC20ToNativeSrcHook.t.sol
+++ b/test/foundry/SC_ERC20ToNativeSrcHook.t.sol
@@ -179,7 +179,12 @@ contract SC_ERC20ToNativeSrcHook_Test is TestUtils {
         // Verify token transfers
         assertEq(inputToken.balanceOf(userSC), initialUserTokens - INPUT_AMOUNT, "User should spend input tokens");
         assertEq(userSC.balance, initialUserNative + OUTPUT_AMOUNT, "User should receive native tokens");
-        assertEq(solverSC.balance, initialSolverNative + EXPECTED_SURPLUS, "Solver should receive surplus native tokens");
+        // Surplus goes to solver's unlocked balance in contract, not direct ETH transfer
+        assertEq(
+            localLens.getUnlockedBalances(solverSC, NATIVE_TOKEN),
+            EXPECTED_SURPLUS,
+            "Solver should receive surplus native tokens in unlocked balance"
+        );
 
         // Verify order status is Settled (atomic settlement for single-chain with srcHook)
         assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Settled, "Order should be Settled");
@@ -280,7 +285,9 @@ contract SC_ERC20ToNativeSrcHook_Test is TestUtils {
         assertEq(localLens.getUnlockedBalances(userSC, address(inputToken)), 0, "User should have no unlocked balance for srcHook swaps");
         assertEq(localLens.getLockedBalances(solverSC, NATIVE_TOKEN), 0, "Solver should have no locked native balance");
         assertEq(
-            localLens.getUnlockedBalances(solverSC, NATIVE_TOKEN), 0, "Solver should have no unlocked native balance for srcHook swaps"
+            localLens.getUnlockedBalances(solverSC, NATIVE_TOKEN),
+            EXPECTED_SURPLUS,
+            "Solver should have surplus in unlocked native balance"
         );
     }
 
@@ -300,7 +307,7 @@ contract SC_ERC20ToNativeSrcHook_Test is TestUtils {
         assertEq(localLens.getLockedBalances(userSC, address(inputToken)), 0);
         assertEq(localLens.getUnlockedBalances(userSC, address(inputToken)), 0);
         assertEq(localLens.getLockedBalances(solverSC, NATIVE_TOKEN), 0);
-        assertEq(localLens.getUnlockedBalances(solverSC, NATIVE_TOKEN), 0);
+        assertEq(localLens.getUnlockedBalances(solverSC, NATIVE_TOKEN), EXPECTED_SURPLUS);
 
         // Order should be immediately settled
         assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Settled, "Order should be Settled");
@@ -430,7 +437,11 @@ contract SC_ERC20ToNativeSrcHook_Test is TestUtils {
 
         // Verify no locked balances remain (atomic settlement with direct distribution)
         assertEq(localLens.getLockedBalances(userSC, address(inputToken)), 0, "User should have no locked balance after atomic settlement");
-        assertEq(localLens.getUnlockedBalances(solverSC, NATIVE_TOKEN), 0, "Solver should have no unlocked balance for srcHook swaps");
+        assertEq(
+            localLens.getUnlockedBalances(solverSC, NATIVE_TOKEN),
+            EXPECTED_SURPLUS,
+            "Solver should have surplus in unlocked balance"
+        );
 
         // Verify tokens were transferred directly (not through balance accounting)
         // User should have received native tokens directly
@@ -539,6 +550,7 @@ contract SC_ERC20ToNativeSrcHook_Test is TestUtils {
         uint256 initialUserNative = testUser.balance;
         uint256 initialSolverNative = testSolver.balance;
         uint256 initialHookNative = address(mockHook2).balance;
+        uint256 initialSolverUnlocked = localLens.getUnlockedBalances(testSolver, NATIVE_TOKEN);
 
         console.log("Before Transaction:");
         console.log("  User Native:", initialUserNative / 1e18, "ETH");
@@ -565,12 +577,12 @@ contract SC_ERC20ToNativeSrcHook_Test is TestUtils {
 
         // Calculate actual changes
         uint256 userReceived = finalUserNative - initialUserNative;
-        uint256 solverReceived = finalSolverNative - initialSolverNative;
+        uint256 solverUnlockedDelta = localLens.getUnlockedBalances(testSolver, NATIVE_TOKEN) - initialSolverUnlocked;
         uint256 hookSent = initialHookNative - finalHookNative;
 
         console.log("Actual Changes:");
         console.log("  User Received:", userReceived / 1e18, "ETH");
-        console.log("  Solver Received:", solverReceived / 1e18, "ETH");
+        console.log("  Solver Unlocked:", solverUnlockedDelta / 1e18, "ETH");
         console.log("  Hook Sent:", hookSent / 1e18, "ETH");
 
         // Verify surplus calculation
@@ -582,13 +594,13 @@ contract SC_ERC20ToNativeSrcHook_Test is TestUtils {
 
         // Assertions
         assertEq(userReceived, OUTPUT_AMOUNT, string(abi.encodePacked(scenarioName, ": User should receive exact output amount")));
-        assertEq(solverReceived, expectedSurplus, string(abi.encodePacked(scenarioName, ": Solver should receive expected surplus")));
+        assertEq(solverUnlockedDelta, expectedSurplus, string(abi.encodePacked(scenarioName, ": Solver should receive expected surplus")));
         assertEq(hookSent, hookOutput, string(abi.encodePacked(scenarioName, ": Hook should send expected amount")));
 
-        // Verify the math: hookOutput = userReceived + solverReceived
+        // Verify the math: hookOutput = userReceived + solverUnlockedDelta
         assertEq(
             hookOutput,
-            userReceived + solverReceived,
+            userReceived + solverUnlockedDelta,
             string(abi.encodePacked(scenarioName, ": Hook output should equal user + solver amounts"))
         );
 

--- a/test/foundry/SC_NativeHookAtomicSwap.t.sol
+++ b/test/foundry/SC_NativeHookAtomicSwap.t.sol
@@ -191,8 +191,12 @@ contract SC_NativeHookAtomicSwap_Test is TestUtils {
         // Verify user received output tokens
         assertEq(outputToken.balanceOf(userSC), initialUserTokens + OUTPUT_AMOUNT, "User should receive output tokens");
 
-        // Verify solver received surplus
-        assertEq(outputToken.balanceOf(solverSC), initialSolverTokens + EXPECTED_SURPLUS, "Solver should receive surplus tokens");
+        // Verify solver received surplus in unlocked balance
+        assertEq(
+            localLens.getUnlockedBalances(solverSC, address(outputToken)),
+            EXPECTED_SURPLUS,
+            "Solver should receive surplus tokens in unlocked balance"
+        );
 
         // Verify order status is Settled
         assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Settled, "Order should be Settled");
@@ -212,7 +216,9 @@ contract SC_NativeHookAtomicSwap_Test is TestUtils {
         uint256 solverTokenGain = outputToken.balanceOf(solverSC) - initialSolverTokens;
 
         assertEq(userTokenGain, OUTPUT_AMOUNT, "User should receive exactly outputAmount");
-        assertEq(solverTokenGain, EXPECTED_SURPLUS, "Solver should receive exactly the surplus");
+        // Surplus goes to solver's unlocked balance in contract, not direct wallet transfer
+        uint256 solverUnlocked = localLens.getUnlockedBalances(solverSC, address(outputToken));
+        assertEq(solverUnlocked, EXPECTED_SURPLUS, "Solver should receive exactly the surplus in unlocked balance");
     }
 
     /**
@@ -270,7 +276,11 @@ contract SC_NativeHookAtomicSwap_Test is TestUtils {
         // No locked balances should remain for atomic settlement
         assertEq(localLens.getLockedBalances(userSC, NATIVE_TOKEN), 0, "User should have no locked native balance");
         assertEq(localLens.getLockedBalances(userSC, address(outputToken)), 0, "User should have no locked output token balance");
-        assertEq(localLens.getUnlockedBalances(solverSC, address(outputToken)), 0, "Solver should have no unlocked balance in contract");
+        assertEq(
+            localLens.getUnlockedBalances(solverSC, address(outputToken)),
+            EXPECTED_SURPLUS,
+            "Solver should have surplus in unlocked balance"
+        );
     }
 
     /**
@@ -379,8 +389,12 @@ contract SC_NativeHookAtomicSwap_Test is TestUtils {
         vm.prank(userSC);
         localAori.depositNative{ value: INPUT_AMOUNT }(order, srcHook);
 
-        // Surplus should go to specified solver
-        assertEq(outputToken.balanceOf(specifiedSolver) - solverBalBefore, EXPECTED_SURPLUS, "Surplus should go to specified solver");
+        // Surplus goes to specified solver's unlocked balance in contract
+        assertEq(
+            localLens.getUnlockedBalances(specifiedSolver, address(outputToken)),
+            EXPECTED_SURPLUS,
+            "Surplus should go to specified solver's unlocked balance"
+        );
     }
 
     /**
@@ -438,7 +452,11 @@ contract SC_NativeHookAtomicSwap_Test is TestUtils {
 
         assertEq(userSC.balance, initialUserNative - INPUT_AMOUNT, "User spent 1 ETH");
         assertEq(outputToken.balanceOf(userSC), initialUserTokens + OUTPUT_AMOUNT, "User received 1000 tokens");
-        assertEq(outputToken.balanceOf(solverSC), initialSolverTokens + EXPECTED_SURPLUS, "Solver received 100 token surplus");
+        assertEq(
+            localLens.getUnlockedBalances(solverSC, address(outputToken)),
+            EXPECTED_SURPLUS,
+            "Solver received 100 token surplus in unlocked balance"
+        );
         assertEq(address(mockHook2).balance, initialHookNative + INPUT_AMOUNT, "Hook received 1 ETH");
         assertEq(outputToken.balanceOf(address(mockHook2)), initialHookTokens - HOOK_OUTPUT, "Hook sent 1100 tokens");
 

--- a/test/foundry/SC_NativeToERC20Hook.t.sol
+++ b/test/foundry/SC_NativeToERC20Hook.t.sol
@@ -244,8 +244,11 @@ contract SC_NativeToERC20Hook_Test is TestUtils {
         assertEq(
             dstPreferredToken.balanceOf(solverSC), preFillSolverPreferredTokens - PREFERRED_AMOUNT, "Solver should spend preferred tokens"
         );
+        // Surplus goes to solver's unlocked balance in contract
         assertEq(
-            outputToken.balanceOf(solverSC), preFillSolverOutputTokens + EXPECTED_SURPLUS, "Solver should receive surplus output tokens"
+            localLens.getUnlockedBalances(solverSC, address(outputToken)),
+            EXPECTED_SURPLUS,
+            "Solver should receive surplus in unlocked balance"
         );
 
         // Verify order status is Settled (atomic settlement for single-chain)


### PR DESCRIPTION
Fixed fee calculations in tests, instead of checking balance of solver and expecting it to be `+= fee`, it should remain the same and their `unlockedBalance` should increase by `fee`

also deleted stale / duplicated event definitions in tests, using `IAori.<event>` now