### PR TITLE
3.3 - Separate srcSolver & dstSolver in Options struct

### DIFF
--- a/contracts/Aori.sol
+++ b/contracts/Aori.sol
@@ -9,7 +9,6 @@ import { ISignatureTransfer } from "@permit2/src/interfaces/ISignatureTransfer.s
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { PayloadType, PayloadUtils } from "./utils/PayloadUtils.sol";
-import { PayloadType, PayloadUtils } from "./utils/PayloadUtils.sol";
 import { AoriStorage, AoriStorageData } from "./AoriStorage.sol";
 import { AoriAtomicSwapLib } from "./lib/AoriAtomicSwapLib.sol";
 import { ValidationUtils } from "./utils/ValidationUtils.sol";
@@ -313,7 +312,7 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, PausableUpgradeable, UUPSU
 
         if (order.isSingleChainSwap()) {
             // Atomic path: execute swap with slippage + fee logic
-            address solver = order.options.solver == address(0) ? msg.sender : order.options.solver;
+            address solver = order.options.srcSolver == address(0) ? msg.sender : order.options.srcSolver;
             AoriAtomicSwapLib.executeSwap(orderId, order, hook, solver);
         } else {
             // Non-atomic path: convert to preferredToken, lock for settlement
@@ -358,7 +357,7 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, PausableUpgradeable, UUPSU
 
         if (order.isSingleChainSwap()) {
             // Atomic path: execute swap with slippage + fee logic
-            address solver = order.options.solver == address(0) ? msg.sender : order.options.solver;
+            address solver = order.options.srcSolver == address(0) ? msg.sender : order.options.srcSolver;
             AoriAtomicSwapLib.executeSwap(orderId, order, hook, solver);
         } else {
             // Non-atomic path: convert to preferredToken, lock for settlement
@@ -429,7 +428,7 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, PausableUpgradeable, UUPSU
 
         if (order.isSingleChainSwap()) {
             // Atomic path: execute swap with slippage + fee logic
-            address solver = order.options.solver == address(0) ? msg.sender : order.options.solver;
+            address solver = order.options.srcSolver == address(0) ? msg.sender : order.options.srcSolver;
             AoriAtomicSwapLib.executeSwap(orderId, order, hook, solver);
         } else {
             // Non-atomic path: convert to preferredToken, lock for settlement

--- a/contracts/Aori.sol
+++ b/contracts/Aori.sol
@@ -704,13 +704,6 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, PausableUpgradeable, UUPSU
         return _hashTypedDataSansChainId(Permit2Lib.hashOrder(order));
     }
 
-    /**
-     * @notice Computes the hash of an order
-     * @param order The order to hash
-     * @return The computed hash
-     */
-    function hash(Order calldata order) public pure returns (bytes32) { return keccak256(abi.encode(order)); }
-
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                     UUPS UPGRADEABILITY                     */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/

--- a/contracts/AoriLens.sol
+++ b/contracts/AoriLens.sol
@@ -115,6 +115,11 @@ contract AoriLens {
     }
 
     /**
+     * @notice Computes the hash of an order
+     */
+    function hash(Order calldata order) external pure returns (bytes32) { return keccak256(abi.encode(order)); }
+
+    /**
      * @notice Get locked balance for a user and token
      */
     function getLockedBalances(address user, address token) external view returns (uint256) {

--- a/contracts/AoriLens.sol
+++ b/contracts/AoriLens.sol
@@ -80,34 +80,38 @@ contract AoriLens {
         bytes32 slot4 = aori.readStorage(bytes32(uint256(baseSlot) + 4));
         bytes32 slot5 = aori.readStorage(bytes32(uint256(baseSlot) + 5));
         bytes32 slot6 = aori.readStorage(bytes32(uint256(baseSlot) + 6));
+        bytes32 slot7 = aori.readStorage(bytes32(uint256(baseSlot) + 7));
 
         // Slot 0: inputAmount (lower 128) | outputAmount (upper 128)
         order.inputAmount = uint128(uint256(slot0));
         order.outputAmount = uint128(uint256(slot0) >> 128);
 
-        // Slot 1: inputToken (lower 160)
+        // Slot 1: inputToken (lower 160) | startTime | endTime | srcEid (packed)
         order.inputToken = address(uint160(uint256(slot1)));
+        order.startTime = uint32(uint256(slot1) >> 160);
+        order.endTime = uint32(uint256(slot1) >> 192);
+        order.srcEid = uint32(uint256(slot1) >> 224);
 
-        // Slot 2: outputToken (lower 160) | startTime | endTime | srcEid (packed)
+        // Slot 2: outputToken (lower 160) | dstEid (bits 160-191)
         order.outputToken = address(uint160(uint256(slot2)));
-        order.startTime = uint32(uint256(slot2) >> 160);
-        order.endTime = uint32(uint256(slot2) >> 192);
-        order.srcEid = uint32(uint256(slot2) >> 224);
+        order.dstEid = uint32(uint256(slot2) >> 160);
 
-        // Slot 3: dstEid (lower 32) | offerer (bits 32-191)
-        order.dstEid = uint32(uint256(slot3));
-        order.offerer = address(uint160(uint256(slot3) >> 32));
+        // Slot 3: offerer (lower 160)
+        order.offerer = address(uint160(uint256(slot3)));
 
         // Slot 4: recipient (lower 160)
         order.recipient = address(uint160(uint256(slot4)));
 
-        // Slot 5: Options.feeMbps (lower 16) | Options.feeRecipient (bits 16-175)
+        // Slot 5: Options.feeMbps (lower 16) | Options.slippageMbps (bits 16-31) | Options.feeRecipient (bits 32-191)
         order.options.feeMbps = uint16(uint256(slot5));
-        order.options.feeRecipient = address(uint160(uint256(slot5) >> 16));
+        order.options.slippageMbps = uint16(uint256(slot5) >> 16);
+        order.options.feeRecipient = address(uint160(uint256(slot5) >> 32));
 
-        // Slot 6: Options.solver (lower 160) | Options.slippageMbps (bits 160-175)
-        order.options.solver = address(uint160(uint256(slot6)));
-        order.options.slippageMbps = uint16(uint256(slot6) >> 160);
+        // Slot 6: Options.srcSolver (lower 160)
+        order.options.srcSolver = address(uint160(uint256(slot6)));
+
+        // Slot 7: Options.dstSolver (lower 160)
+        order.options.dstSolver = address(uint160(uint256(slot7)));
     }
 
     /**

--- a/contracts/interfaces/IAori.sol
+++ b/contracts/interfaces/IAori.sol
@@ -217,8 +217,6 @@ interface IAori {
 
     function getMaxFillsPerSettle() external view returns (uint16);
 
-    function hash(Order calldata order) external pure returns (bytes32);
-
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                        SRC FUNCTIONS                       */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/

--- a/contracts/types/AoriTypes.sol
+++ b/contracts/types/AoriTypes.sol
@@ -9,10 +9,10 @@ struct Order {
     uint128 inputAmount;
     uint128 outputAmount;
     address inputToken;
-    address outputToken;
     uint32 startTime;
     uint32 endTime;
     uint32 srcEid;
+    address outputToken;
     uint32 dstEid;
     address offerer;
     address recipient;
@@ -25,9 +25,10 @@ struct Order {
 
 struct Options {
     uint16 feeMbps;       // Fee in millibasis points (1000 = 1%)
-    address feeRecipient; // Who receives the fee (address(0) = solver)
-    address solver;       // Authorized solver (address(0) = any whitelisted)
     uint16 slippageMbps;  // 0 = limit order, >0 = market order
+    address feeRecipient; // Who receives the fee (address(0) = solver)
+    address srcSolver;    // Authorized solver on source chain (address(0) = any whitelisted)
+    address dstSolver;    // Authorized solver on destination chain (address(0) = any whitelisted)
 }
 
 /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/

--- a/contracts/utils/Permit2Lib.sol
+++ b/contracts/utils/Permit2Lib.sol
@@ -26,15 +26,15 @@ library Permit2Lib {
      * @dev Options typehash for witness hashing
      */
     bytes32 internal constant OPTIONS_TYPEHASH =
-        keccak256("Options(uint16 feeMbps,address feeRecipient,address solver,uint16 slippageMbps)");
+        keccak256("Options(uint16 feeMbps,uint16 slippageMbps,address feeRecipient,address srcSolver,address dstSolver)");
 
     /**
      * @dev Order typehash for witness hashing (includes nested Options)
      */
     bytes32 internal constant ORDER_TYPEHASH = keccak256(
-        "Order(uint128 inputAmount,uint128 outputAmount,address inputToken,address outputToken,"
-        "uint32 startTime,uint32 endTime,uint32 srcEid,uint32 dstEid,address offerer,address recipient," "Options options)"
-        "Options(uint16 feeMbps,address feeRecipient,address solver,uint16 slippageMbps)"
+        "Order(uint128 inputAmount,uint128 outputAmount,address inputToken,uint32 startTime,"
+        "uint32 endTime,uint32 srcEid,address outputToken,uint32 dstEid,address offerer,address recipient," "Options options)"
+        "Options(uint16 feeMbps,uint16 slippageMbps,address feeRecipient,address srcSolver,address dstSolver)"
     );
 
     /**
@@ -44,9 +44,9 @@ library Permit2Lib {
      * Alphabetical ordering per EIP-712: Options (O) < Order (O) < TokenPermissions (T)
      */
     string internal constant WITNESS_TYPE_STRING = "Order witness)"
-        "Options(uint16 feeMbps,address feeRecipient,address solver,uint16 slippageMbps)"
-        "Order(uint128 inputAmount,uint128 outputAmount,address inputToken,address outputToken,"
-        "uint32 startTime,uint32 endTime,uint32 srcEid,uint32 dstEid,address offerer,address recipient," "Options options)"
+        "Options(uint16 feeMbps,uint16 slippageMbps,address feeRecipient,address srcSolver,address dstSolver)"
+        "Order(uint128 inputAmount,uint128 outputAmount,address inputToken,uint32 startTime,"
+        "uint32 endTime,uint32 srcEid,address outputToken,uint32 dstEid,address offerer,address recipient," "Options options)"
         "TokenPermissions(address token,uint256 amount)";
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -61,7 +61,7 @@ library Permit2Lib {
     function hashOptions(
         Options calldata options
     ) internal pure returns (bytes32) {
-        return keccak256(abi.encode(OPTIONS_TYPEHASH, options.feeMbps, options.feeRecipient, options.solver, options.slippageMbps));
+        return keccak256(abi.encode(OPTIONS_TYPEHASH, options.feeMbps, options.slippageMbps, options.feeRecipient, options.srcSolver, options.dstSolver));
     }
 
     /**
@@ -77,10 +77,10 @@ library Permit2Lib {
                 order.inputAmount,
                 order.outputAmount,
                 order.inputToken,
-                order.outputToken,
                 order.startTime,
                 order.endTime,
                 order.srcEid,
+                order.outputToken,
                 order.dstEid,
                 order.offerer,
                 order.recipient,

--- a/contracts/utils/ValidationUtils.sol
+++ b/contracts/utils/ValidationUtils.sol
@@ -77,7 +77,7 @@ library ValidationUtils {
         if (!SignatureCheckerLib.isValidSignatureNowCalldata(order.offerer, digest, signature)) {
             revert InvalidSignature();
         }
-        if (order.options.solver != address(0) && solver != order.options.solver) {
+        if (order.options.srcSolver != address(0) && solver != order.options.srcSolver) {
             revert UnauthorizedSolver();
         }
         validateCommonOrderParams(order, maxFeeMbps);
@@ -109,14 +109,14 @@ library ValidationUtils {
     }
 
     /**
-     * @notice Validates that the caller is the solver specified in the order
-     * @dev No-op when order.options.solver is address(0) (any whitelisted solver allowed)
+     * @notice Validates that the caller is the srcSolver specified in the order
+     * @dev No-op when order.options.srcSolver is address(0) (any whitelisted solver allowed)
      * @param order The order to check
      * @param solver The address to validate (typically msg.sender)
      */
     /* forgefmt: disable-next-item */
     function validateSolverAuthorization(Order calldata order, address solver) internal pure {
-        if (order.options.solver != address(0) && solver != order.options.solver) revert UnauthorizedSolver();
+        if (order.options.srcSolver != address(0) && solver != order.options.srcSolver) revert UnauthorizedSolver();
     }
 
     /**
@@ -140,8 +140,8 @@ library ValidationUtils {
         validateCommonOrderParams(order, maxFeeMbps);
         if (order.dstEid != endpointId) revert ChainMismatch(endpointId, order.dstEid);
 
-        // Solver authorization: if order specifies a solver, only that solver can fill
-        if (order.options.solver != address(0) && solver != order.options.solver) {
+        // Solver authorization: if order specifies a dstSolver, only that solver can fill
+        if (order.options.dstSolver != address(0) && solver != order.options.dstSolver) {
             revert UnauthorizedSolver();
         }
 

--- a/test/foundry/12_PausedTests.t.sol
+++ b/test/foundry/12_PausedTests.t.sol
@@ -145,7 +145,7 @@ contract PausedTests is TestUtils {
         localAori.deposit(order, signature);
 
         // Get the order hash
-        bytes32 orderHash = localAori.hash(order);
+        bytes32 orderHash = keccak256(abi.encode(order));
 
         // Advance time past expiry BEFORE cancellation
         vm.warp(order.endTime + 1);

--- a/test/foundry/13_CrossChainAndExclusivityTests.t.sol
+++ b/test/foundry/13_CrossChainAndExclusivityTests.t.sol
@@ -135,7 +135,7 @@ contract CrossChainAndWhitelistTests is TestUtils {
         settlementPayload[22] = bytes1(uint8(uint16(fillCount)));
 
         // Order hash
-        bytes32 orderHash = localAori.hash(order);
+        bytes32 orderHash = keccak256(abi.encode(order));
         for (uint256 i = 0; i < 32; i++) {
             settlementPayload[23 + i] = orderHash[i];
         }
@@ -182,7 +182,7 @@ contract CrossChainAndWhitelistTests is TestUtils {
         vm.warp(order.endTime + 1);
 
         // Whitelisted solver cancels the order
-        bytes32 orderHash = localAori.hash(order);
+        bytes32 orderHash = keccak256(abi.encode(order));
         vm.prank(solver);
         localAori.cancel(orderHash);
 
@@ -224,7 +224,7 @@ contract CrossChainAndWhitelistTests is TestUtils {
         vm.warp(order.endTime + 1);
 
         // Non-whitelisted solver tries to cancel - should fail
-        bytes32 orderHash = localAori.hash(order);
+        bytes32 orderHash = keccak256(abi.encode(order));
 
         // Place expectRevert directly before the call that should revert
         vm.prank(nonWhitelistedSolver);
@@ -285,7 +285,7 @@ contract CrossChainAndWhitelistTests is TestUtils {
         // Try to cancel after fill - should revert
         vm.deal(userA, fee);
         vm.prank(userA);
-        bytes32 orderHash = localAori.hash(order);
+        bytes32 orderHash = keccak256(abi.encode(order));
         // Add a check to verify the order state is actually Filled
         assertEq(uint8(remoteAori.orderStatus(orderHash)), uint8(OrderStatus.Filled), "Order should be in filled state");
         vm.expectRevert(abi.encodeWithSelector(OrderAlreadyProcessed.selector, OrderStatus.Filled));
@@ -323,7 +323,7 @@ contract CrossChainAndWhitelistTests is TestUtils {
 
         vm.deal(userA, cancelFee);
         vm.startPrank(userA);
-        bytes32 orderHash = localAori.hash(order);
+        bytes32 orderHash = keccak256(abi.encode(order));
         remoteAori.cancel{ value: cancelFee }(orderHash, order, options);
         vm.stopPrank();
 

--- a/test/foundry/15_SecurityAndAdvancedEdgeCasesTest.t.sol
+++ b/test/foundry/15_SecurityAndAdvancedEdgeCasesTest.t.sol
@@ -511,28 +511,29 @@ contract SecurityAndAdvancedEdgeCasesTest is TestUtils {
         // Hash the nested Options struct first
         bytes32 optionsHash = keccak256(
             abi.encode(
-                keccak256("Options(uint16 feeMbps,address feeRecipient,address solver,uint16 slippageMbps)"),
+                keccak256("Options(uint16 feeMbps,uint16 slippageMbps,address feeRecipient,address srcSolver,address dstSolver)"),
                 order.options.feeMbps,
+                order.options.slippageMbps,
                 order.options.feeRecipient,
-                order.options.solver,
-                order.options.slippageMbps
+                order.options.srcSolver,
+                order.options.dstSolver
             )
         );
 
         bytes32 structHash = keccak256(
             abi.encode(
                 keccak256(
-                    "Order(uint128 inputAmount,uint128 outputAmount,address inputToken,address outputToken,"
-                    "uint32 startTime,uint32 endTime,uint32 srcEid,uint32 dstEid,address offerer,address recipient," "Options options)"
-                    "Options(uint16 feeMbps,address feeRecipient,address solver,uint16 slippageMbps)"
+                    "Order(uint128 inputAmount,uint128 outputAmount,address inputToken,"
+                    "uint32 startTime,uint32 endTime,uint32 srcEid,address outputToken,uint32 dstEid,address offerer,address recipient," "Options options)"
+                    "Options(uint16 feeMbps,uint16 slippageMbps,address feeRecipient,address srcSolver,address dstSolver)"
                 ),
                 order.inputAmount,
                 order.outputAmount,
                 order.inputToken,
-                order.outputToken,
                 order.startTime,
                 order.endTime,
                 order.srcEid,
+                order.outputToken,
                 order.dstEid,
                 order.offerer,
                 order.recipient,

--- a/test/foundry/17_TestCrossChainCancelAndSettle.t.sol
+++ b/test/foundry/17_TestCrossChainCancelAndSettle.t.sol
@@ -59,7 +59,7 @@ contract CrossChainCancelAndSettleTest is TestUtils {
         vm.chainId(remoteEid);
 
         // Set up the order on the destination chain
-        bytes32 orderHash = remoteAori.hash(order);
+        bytes32 orderHash = keccak256(abi.encode(order));
         remoteLens.orders(orderHash); // This will create the order in storage
 
         // Calculate LZ message fee
@@ -107,7 +107,7 @@ contract CrossChainCancelAndSettleTest is TestUtils {
         vm.chainId(remoteEid);
 
         // Set up the order on the destination chain
-        bytes32 orderHash = remoteAori.hash(order);
+        bytes32 orderHash = keccak256(abi.encode(order));
         remoteLens.orders(orderHash); // This will create the order in storage
 
         // Warp past endTime

--- a/test/foundry/18_QuoteTest.t.sol
+++ b/test/foundry/18_QuoteTest.t.sol
@@ -67,7 +67,7 @@ contract QuoteTest is TestUtils {
         localAori.deposit(order, signature);
 
         // Get order hash
-        orderHash = localAori.hash(order);
+        orderHash = keccak256(abi.encode(order));
     }
 
     /// @dev Test quoting for cancel message (33 bytes)

--- a/test/foundry/19_EdgeCases.t.sol
+++ b/test/foundry/19_EdgeCases.t.sol
@@ -182,17 +182,17 @@ contract EdgeCasesTest is TestUtils {
     function _getOrderDigest(
         Order memory order
     ) internal view returns (bytes32) {
-        bytes32 OPTIONS_TYPEHASH = keccak256("Options(uint16 feeMbps,address feeRecipient,address solver,uint16 slippageMbps)");
+        bytes32 OPTIONS_TYPEHASH = keccak256("Options(uint16 feeMbps,uint16 slippageMbps,address feeRecipient,address srcSolver,address dstSolver)");
         bytes32 ORDER_TYPEHASH = keccak256(
-            "Order(uint128 inputAmount,uint128 outputAmount,address inputToken,address outputToken,"
-            "uint32 startTime,uint32 endTime,uint32 srcEid,uint32 dstEid,address offerer,address recipient," "Options options)"
-            "Options(uint16 feeMbps,address feeRecipient,address solver,uint16 slippageMbps)"
+            "Order(uint128 inputAmount,uint128 outputAmount,address inputToken,"
+            "uint32 startTime,uint32 endTime,uint32 srcEid,address outputToken,uint32 dstEid,address offerer,address recipient," "Options options)"
+            "Options(uint16 feeMbps,uint16 slippageMbps,address feeRecipient,address srcSolver,address dstSolver)"
         );
 
         // Hash options first
         bytes32 optionsHash = keccak256(
             abi.encode(
-                OPTIONS_TYPEHASH, order.options.feeMbps, order.options.feeRecipient, order.options.solver, order.options.slippageMbps
+                OPTIONS_TYPEHASH, order.options.feeMbps, order.options.slippageMbps, order.options.feeRecipient, order.options.srcSolver, order.options.dstSolver
             )
         );
 
@@ -202,10 +202,10 @@ contract EdgeCasesTest is TestUtils {
                 order.inputAmount,
                 order.outputAmount,
                 order.inputToken,
-                order.outputToken,
                 order.startTime,
                 order.endTime,
                 order.srcEid,
+                order.outputToken,
                 order.dstEid,
                 order.offerer,
                 order.recipient,

--- a/test/foundry/1_SingleOrder.t.sol
+++ b/test/foundry/1_SingleOrder.t.sol
@@ -78,7 +78,7 @@ contract SingleOrderSuccessTest is TestUtils {
             uint8(0), // message type 0 for settlement
             solver, // filler address
             uint16(1), // fill count
-            localAori.hash(order) // order hash
+            keccak256(abi.encode(order)) // order hash
         );
 
         vm.prank(address(endpoints[localEid]));

--- a/test/foundry/21_OrderIdConsistencyTest.t.sol
+++ b/test/foundry/21_OrderIdConsistencyTest.t.sol
@@ -25,7 +25,7 @@ contract OrderIdConsistencyTest is TestUtils {
         order = createValidOrder();
 
         // Calculate the expected orderId using the hash function
-        bytes32 expectedOrderId = localAori.hash(order);
+        bytes32 expectedOrderId = keccak256(abi.encode(order));
 
         // Generate signature and approve tokens
         bytes memory signature = signOrder(order);

--- a/test/foundry/22_HashVerificationTest.t.sol
+++ b/test/foundry/22_HashVerificationTest.t.sol
@@ -185,7 +185,7 @@ contract HashVerificationTest is TestUtils {
         Aori(ARBITRUM_CONTRACT_ADDRESS).deposit(order, signature);
 
         // Verify the deposit was successful
-        bytes32 orderHash = Aori(ARBITRUM_CONTRACT_ADDRESS).hash(order);
+        bytes32 orderHash = keccak256(abi.encode(order));
         uint8 status = uint8(Aori(ARBITRUM_CONTRACT_ADDRESS).orderStatus(orderHash));
 
         console.log("\n---- DEPOSIT RESULT ----");
@@ -208,28 +208,29 @@ contract HashVerificationTest is TestUtils {
         // Hash the nested Options struct first
         bytes32 optionsHash = keccak256(
             abi.encode(
-                keccak256("Options(uint16 feeMbps,address feeRecipient,address solver,uint16 slippageMbps)"),
+                keccak256("Options(uint16 feeMbps,uint16 slippageMbps,address feeRecipient,address srcSolver,address dstSolver)"),
                 order.options.feeMbps,
+                order.options.slippageMbps,
                 order.options.feeRecipient,
-                order.options.solver,
-                order.options.slippageMbps
+                order.options.srcSolver,
+                order.options.dstSolver
             )
         );
 
         bytes32 structHash = keccak256(
             abi.encode(
                 keccak256(
-                    "Order(uint128 inputAmount,uint128 outputAmount,address inputToken,address outputToken,"
-                    "uint32 startTime,uint32 endTime,uint32 srcEid,uint32 dstEid,address offerer,address recipient," "Options options)"
-                    "Options(uint16 feeMbps,address feeRecipient,address solver,uint16 slippageMbps)"
+                    "Order(uint128 inputAmount,uint128 outputAmount,address inputToken,"
+                    "uint32 startTime,uint32 endTime,uint32 srcEid,address outputToken,uint32 dstEid,address offerer,address recipient," "Options options)"
+                    "Options(uint16 feeMbps,uint16 slippageMbps,address feeRecipient,address srcSolver,address dstSolver)"
                 ),
                 order.inputAmount,
                 order.outputAmount,
                 order.inputToken,
-                order.outputToken,
                 order.startTime,
                 order.endTime,
                 order.srcEid,
+                order.outputToken,
                 order.dstEid,
                 order.offerer,
                 order.recipient,

--- a/test/foundry/28_singleChainHookTests.t.sol
+++ b/test/foundry/28_singleChainHookTests.t.sol
@@ -128,7 +128,7 @@ contract SingleChainHookTest is TestUtils {
         });
 
         // Calculate order ID
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         // We need to disable validation or bypass it for the test to work
         // In a single-chain deposit with hook scenario, the token doesn't actually enter
@@ -194,7 +194,7 @@ contract SingleChainHookTest is TestUtils {
         outputToken.approve(address(localAori), type(uint256).max);
 
         // Calculate order ID
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         // Create hook structure
         SrcHook memory hook = SrcHook({
@@ -273,7 +273,7 @@ contract SingleChainHookTest is TestUtils {
         });
 
         // Deposit with hook - this will immediately settle for single-chain swaps
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
         vm.prank(solver);
         localAori.deposit(order, signature, hook);
 

--- a/test/foundry/29_singleChainSwapTests.t.sol
+++ b/test/foundry/29_singleChainSwapTests.t.sol
@@ -120,7 +120,7 @@ contract SingleChainSwapTests is TestUtils {
         uint256 initialOutputTokenRecipient = outputToken.balanceOf(recipient);
 
         // Calculate order ID
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         // Step 1: Execute deposit - This is the key operation we're testing
         vm.prank(solver);
@@ -182,7 +182,7 @@ contract SingleChainSwapTests is TestUtils {
         uint256 initialOutputTokenRecipient = outputToken.balanceOf(recipient);
 
         // Calculate order ID
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         // Step 1: Execute deposit with primary solver
         vm.prank(solver);
@@ -245,7 +245,7 @@ contract SingleChainSwapTests is TestUtils {
         inputToken.approve(address(localAori), type(uint256).max);
 
         // Calculate order ID
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         // Step 1: Execute deposit
         vm.prank(solver);
@@ -301,7 +301,7 @@ contract SingleChainSwapTests is TestUtils {
         uint256 initialOutputTokenRecipient = outputToken.balanceOf(recipient);
 
         // Calculate order ID
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         // Step 1: Execute deposit
         vm.prank(solver);
@@ -367,7 +367,7 @@ contract SingleChainSwapTests is TestUtils {
         inputToken.approve(address(localAori), type(uint256).max);
 
         // Calculate order ID
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         // Step 1: Execute deposit
         vm.prank(solver);
@@ -421,7 +421,7 @@ contract SingleChainSwapTests is TestUtils {
         inputToken.approve(address(localAori), type(uint256).max);
 
         // Calculate order ID
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         // Step 1: Execute deposit
         vm.prank(solver);
@@ -464,7 +464,7 @@ contract SingleChainSwapTests is TestUtils {
         inputToken.approve(address(localAori), type(uint256).max);
 
         // Calculate order ID
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         // Step 1: Execute deposit
         vm.prank(solver);
@@ -502,7 +502,7 @@ contract SingleChainSwapTests is TestUtils {
         inputToken.approve(address(localAori), type(uint256).max);
 
         // Calculate order ID
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         // Step 1: Execute deposit
         vm.prank(solver);
@@ -606,7 +606,7 @@ contract SingleChainSwapTests is TestUtils {
         // Record balances before operation
         uint256 initialInputBalance = inputToken.balanceOf(userA);
         uint256 initialRecipientBalance = outputToken.balanceOf(recipient);
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         // Execute deposit with hook
         vm.prank(solver);
@@ -808,8 +808,8 @@ contract SingleChainSwapTests is TestUtils {
         assertEq(outputToken.balanceOf(recipient), OUTPUT_AMOUNT * 2, "Recipient should receive the same amount from both paths");
 
         // Verify all orders have the same final status
-        bytes32 id1 = localAori.hash(order1);
-        bytes32 id2 = localAori.hash(order2);
+        bytes32 id1 = keccak256(abi.encode(order1));
+        bytes32 id2 = keccak256(abi.encode(order2));
 
         assertEq(uint8(localAori.orderStatus(id1)), uint8(OrderStatus.Settled), "Order 1 should be settled");
         assertEq(uint8(localAori.orderStatus(id2)), uint8(OrderStatus.Settled), "Order 2 should be settled");

--- a/test/foundry/2_MultiOrder.t.sol
+++ b/test/foundry/2_MultiOrder.t.sol
@@ -158,7 +158,7 @@ contract MultiOrderSuccessTest is TestUtils {
         settlementPayload[21] = bytes1(uint8(uint16(fillCount) >> 8));
         settlementPayload[22] = bytes1(uint8(uint16(fillCount)));
         for (uint256 i = 0; i < NUM_ORDERS; i++) {
-            bytes32 orderHash = localAori.hash(orders[i]);
+            bytes32 orderHash = keccak256(abi.encode(orders[i]));
             uint256 offset = 23 + i * 32;
             for (uint256 j = 0; j < 32; j++) {
                 settlementPayload[offset + j] = orderHash[j];
@@ -198,7 +198,7 @@ contract MultiOrderSuccessTest is TestUtils {
         settlementPayload[21] = bytes1(uint8(uint16(fillCount) >> 8));
         settlementPayload[22] = bytes1(uint8(uint16(fillCount)));
         for (uint256 i = 0; i < NUM_ORDERS; i++) {
-            bytes32 orderHash = localAori.hash(orders[i]);
+            bytes32 orderHash = keccak256(abi.encode(orders[i]));
             uint256 offset = 23 + i * 32;
             for (uint256 j = 0; j < 32; j++) {
                 settlementPayload[offset + j] = orderHash[j];

--- a/test/foundry/30_supportedChain.t.sol
+++ b/test/foundry/30_supportedChain.t.sol
@@ -126,7 +126,7 @@ contract SupportedChainTest is TestUtils {
         localAori.deposit(order, signature);
 
         // Verify order was created
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
         assertEq(uint8(localAori.orderStatus(orderId)), uint8(OrderStatus.Active), "Order should be active");
     }
 

--- a/test/foundry/31_MessagingReceipt.t.sol
+++ b/test/foundry/31_MessagingReceipt.t.sol
@@ -96,7 +96,7 @@ contract MessagingReceiptTest is TestUtils {
         // Create and deposit an order
         Order memory order = createValidOrder();
         bytes memory signature = signOrder(order);
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         // Deposit the order on the source chain
         vm.prank(userA);
@@ -156,7 +156,7 @@ contract MessagingReceiptTest is TestUtils {
         Order memory order = createValidOrder();
         order.dstEid = order.srcEid; // Make it a single-chain order
         bytes memory signature = signOrder(order);
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         // Deposit the order
         vm.prank(userA);

--- a/test/foundry/32_EmergencyTests.t.sol
+++ b/test/foundry/32_EmergencyTests.t.sol
@@ -95,7 +95,7 @@ contract EmergencyTests is TestUtils {
         vm.prank(solver);
         localAori.deposit(order, signature);
 
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
         uint256 userBalanceBefore = inputToken.balanceOf(userA);
 
         // Execute emergency cancel
@@ -120,7 +120,7 @@ contract EmergencyTests is TestUtils {
         vm.prank(solver);
         localAori.deposit(order, signature);
 
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
         uint256 recipientBalanceBefore = inputToken.balanceOf(customRecipient);
 
         // Emergency cancel to custom recipient
@@ -146,7 +146,7 @@ contract EmergencyTests is TestUtils {
         vm.prank(solver);
         localAori.deposit(order, signature);
 
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         // Should work on source chain (order.srcEid == localEid)
         localAori.emergencyCancel(orderId, userA);
@@ -170,7 +170,7 @@ contract EmergencyTests is TestUtils {
         vm.prank(solver);
         localAori.deposit(order, signature);
 
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         // Non-owner should fail
         vm.prank(nonOwner);
@@ -195,7 +195,7 @@ contract EmergencyTests is TestUtils {
         vm.prank(solver);
         localAori.deposit(order, signature);
 
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         // Invalid recipient (address(0))
         vm.expectRevert(InvalidRecipient.selector);
@@ -215,7 +215,7 @@ contract EmergencyTests is TestUtils {
         vm.prank(solver);
         localAori.deposit(order, signature);
 
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         // Drain contract balance
         uint256 contractBalance = inputToken.balanceOf(payable(address(localAori)));
@@ -244,7 +244,7 @@ contract EmergencyTests is TestUtils {
         vm.prank(solver);
         localAori.deposit(order, signature);
 
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         // Cancel once
         localAori.emergencyCancel(orderId, userA);
@@ -543,7 +543,7 @@ contract EmergencyTests is TestUtils {
         vm.prank(solver);
         localAori.deposit(order, signature);
 
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         // Step 1: Emergency withdraw tokens
         localAori.emergencyWithdrawFromBalance(
@@ -577,7 +577,7 @@ contract EmergencyTests is TestUtils {
         vm.prank(solver);
         localAori.deposit(order, signature);
 
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         // Emergency cancel
         localAori.emergencyCancel(orderId, userA);
@@ -594,7 +594,7 @@ contract EmergencyTests is TestUtils {
         vm.prank(solver);
         localAori.deposit(newOrder, newSig);
 
-        bytes32 newOrderId = localAori.hash(newOrder);
+        bytes32 newOrderId = keccak256(abi.encode(newOrder));
         assertEq(uint8(localAori.orderStatus(newOrderId)), uint8(OrderStatus.Active), "New order should be active");
 
         // 2. Can perform swaps
@@ -613,7 +613,7 @@ contract EmergencyTests is TestUtils {
         vm.prank(solver);
         localAori.fill(swapOrder);
 
-        bytes32 swapOrderId = localAori.hash(swapOrder);
+        bytes32 swapOrderId = keccak256(abi.encode(swapOrder));
         assertEq(uint8(localAori.orderStatus(swapOrderId)), uint8(OrderStatus.Settled), "Swap should be settled");
 
         // 3. Can withdraw unlocked balances

--- a/test/foundry/34_NativeTokenTests.t.sol
+++ b/test/foundry/34_NativeTokenTests.t.sol
@@ -83,7 +83,7 @@ contract NativeTokenTests is TestUtils {
         assertEq(localLens.getLockedBalances(user, NATIVE_TOKEN), initialLocked + INPUT_AMOUNT, "Locked balance should increase");
 
         // Verify order status
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
         assertTrue(localAori.orderStatus(orderId) == OrderStatus.Active, "Order should be Active");
     }
 
@@ -110,7 +110,7 @@ contract NativeTokenTests is TestUtils {
         localAori.depositNative{ value: INPUT_AMOUNT }(order);
 
         // Verify order status
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
         assertTrue(localAori.orderStatus(orderId) == OrderStatus.Active, "Order should be Active");
     }
 
@@ -136,7 +136,7 @@ contract NativeTokenTests is TestUtils {
         vm.prank(user);
         localAori.depositNative{ value: INPUT_AMOUNT }(order);
 
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
         assertTrue(localAori.orderStatus(orderId) == OrderStatus.Active, "Order should be Active");
     }
 
@@ -322,7 +322,7 @@ contract NativeTokenTests is TestUtils {
         vm.prank(user);
         localAori.depositNative{ value: INPUT_AMOUNT }(order);
 
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
         assertTrue(localAori.orderStatus(orderId) == OrderStatus.Active, "Order should be Active");
     }
 
@@ -619,7 +619,7 @@ contract NativeTokenTests is TestUtils {
         vm.prank(user);
         localAori.depositNative{ value: maxAmount }(order);
 
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
         assertTrue(localAori.orderStatus(orderId) == OrderStatus.Active, "Order should be Active");
     }
 
@@ -645,7 +645,7 @@ contract NativeTokenTests is TestUtils {
         vm.prank(user);
         localAori.depositNative{ value: minAmount }(order);
 
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
         assertTrue(localAori.orderStatus(orderId) == OrderStatus.Active, "Order should be Active");
     }
 
@@ -673,7 +673,7 @@ contract NativeTokenTests is TestUtils {
         vm.prank(user);
         localAori.depositNative{ value: INPUT_AMOUNT }(order);
 
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
         assertTrue(localAori.orderStatus(orderId) == OrderStatus.Active, "Order should be Active");
     }
 
@@ -704,7 +704,7 @@ contract NativeTokenTests is TestUtils {
             vm.prank(user);
             localAori.depositNative{ value: INPUT_AMOUNT }(order);
 
-            bytes32 orderId = localAori.hash(order);
+            bytes32 orderId = keccak256(abi.encode(order));
             assertTrue(localAori.orderStatus(orderId) == OrderStatus.Active, "Order should be Active");
         }
 
@@ -730,7 +730,7 @@ contract NativeTokenTests is TestUtils {
         );
 
         bytes memory signature = signOrder(order, userPrivKey);
-        bytes32 expectedOrderId = localAori.hash(order);
+        bytes32 expectedOrderId = keccak256(abi.encode(order));
 
         vm.expectEmit(true, false, false, true);
         emit IAori.Deposit(expectedOrderId, order, address(0), 0);

--- a/test/foundry/35_Permit2Deposit.t.sol
+++ b/test/foundry/35_Permit2Deposit.t.sol
@@ -18,9 +18,9 @@ contract Permit2DepositTest is TestUtils, DeployPermit2 {
     // Full typehash for PermitWitnessTransferFrom with Order witness (includes nested Options)
     bytes32 constant FULL_PERMIT_WITNESS_TYPEHASH = keccak256(
         "PermitWitnessTransferFrom(TokenPermissions permitted,address spender,uint256 nonce,uint256 deadline,Order witness)"
-        "Options(uint16 feeMbps,address feeRecipient,address solver,uint16 slippageMbps)"
-        "Order(uint128 inputAmount,uint128 outputAmount,address inputToken,address outputToken,"
-        "uint32 startTime,uint32 endTime,uint32 srcEid,uint32 dstEid,address offerer,address recipient," "Options options)"
+        "Options(uint16 feeMbps,uint16 slippageMbps,address feeRecipient,address srcSolver,address dstSolver)"
+        "Order(uint128 inputAmount,uint128 outputAmount,address inputToken,"
+        "uint32 startTime,uint32 endTime,uint32 srcEid,address outputToken,uint32 dstEid,address offerer,address recipient," "Options options)"
         "TokenPermissions(address token,uint256 amount)"
     );
 
@@ -56,9 +56,10 @@ contract Permit2DepositTest is TestUtils, DeployPermit2 {
             abi.encode(
                 Permit2Lib.OPTIONS_TYPEHASH,
                 order.options.feeMbps,
+                order.options.slippageMbps,
                 order.options.feeRecipient,
-                order.options.solver,
-                order.options.slippageMbps
+                order.options.srcSolver,
+                order.options.dstSolver
             )
         );
 
@@ -69,10 +70,10 @@ contract Permit2DepositTest is TestUtils, DeployPermit2 {
                 order.inputAmount,
                 order.outputAmount,
                 order.inputToken,
-                order.outputToken,
                 order.startTime,
                 order.endTime,
                 order.srcEid,
+                order.outputToken,
                 order.dstEid,
                 order.offerer,
                 order.recipient,
@@ -126,7 +127,7 @@ contract Permit2DepositTest is TestUtils, DeployPermit2 {
         assertEq(inputToken.balanceOf(address(localAori)), aoriBalanceBefore + order.inputAmount);
 
         // Check order is stored
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
         assertEq(uint8(localAori.orderStatus(orderId)), uint8(OrderStatus.Active));
 
         // Check locked balance
@@ -149,8 +150,8 @@ contract Permit2DepositTest is TestUtils, DeployPermit2 {
         localAori.depositWithPermit2(order2, 1, deadline, sig2);
 
         // Both orders should be active
-        assertEq(uint8(localAori.orderStatus(localAori.hash(order1))), uint8(OrderStatus.Active));
-        assertEq(uint8(localAori.orderStatus(localAori.hash(order2))), uint8(OrderStatus.Active));
+        assertEq(uint8(localAori.orderStatus(keccak256(abi.encode(order1)))), uint8(OrderStatus.Active));
+        assertEq(uint8(localAori.orderStatus(keccak256(abi.encode(order2)))), uint8(OrderStatus.Active));
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -303,7 +304,7 @@ contract Permit2DepositTest is TestUtils, DeployPermit2 {
         assertEq(inputToken.balanceOf(userA), userBalanceBefore - order.inputAmount);
 
         // Check order is stored
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
         assertEq(uint8(localAori.orderStatus(orderId)), uint8(OrderStatus.Active));
 
         // Check converted token is locked (hook converts input to convertedToken)

--- a/test/foundry/36_Upgrade.t.sol
+++ b/test/foundry/36_Upgrade.t.sol
@@ -330,7 +330,7 @@ contract UpgradeTests is TestHelperOz5 {
             endTime: uint32(block.timestamp + 1 days),
             srcEid: LOCAL_EID,
             dstEid: REMOTE_EID,
-            options: Options({ feeMbps: 0, feeRecipient: address(0), solver: address(0), slippageMbps: 0 })
+            options: Options({ feeMbps: 0, slippageMbps: 0, feeRecipient: address(0), srcSolver: address(0), dstSolver: address(0) })
         });
 
         // Deposit native tokens as userA
@@ -360,7 +360,7 @@ contract UpgradeTests is TestHelperOz5 {
             endTime: uint32(block.timestamp + 1 days),
             srcEid: LOCAL_EID,
             dstEid: LOCAL_EID, // Same chain for simplicity
-            options: Options({ feeMbps: 0, feeRecipient: address(0), solver: address(0), slippageMbps: 0 })
+            options: Options({ feeMbps: 0, slippageMbps: 0, feeRecipient: address(0), srcSolver: address(0), dstSolver: address(0) })
         });
 
         vm.deal(userA, 10e18);
@@ -377,7 +377,7 @@ contract UpgradeTests is TestHelperOz5 {
         vm.warp(order.endTime + 1);
 
         // Cancel the order - this directly transfers tokens back to offerer
-        bytes32 orderId = aori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
         vm.prank(userA);
         aori.cancel(orderId);
 
@@ -407,11 +407,11 @@ contract UpgradeTests is TestHelperOz5 {
             endTime: uint32(block.timestamp + 1 days),
             srcEid: LOCAL_EID,
             dstEid: REMOTE_EID,
-            options: Options({ feeMbps: 0, feeRecipient: address(0), solver: address(0), slippageMbps: 0 })
+            options: Options({ feeMbps: 0, slippageMbps: 0, feeRecipient: address(0), srcSolver: address(0), dstSolver: address(0) })
         });
 
         // Hash should work through proxy
-        bytes32 orderHash = aori.hash(order);
+        bytes32 orderHash = keccak256(abi.encode(order));
         assertTrue(orderHash != bytes32(0), "Order hash should not be zero");
     }
 

--- a/test/foundry/37_AoriLensTests.t.sol
+++ b/test/foundry/37_AoriLensTests.t.sol
@@ -36,7 +36,7 @@ contract AoriLensTests is TestUtils {
         vm.prank(solver);
         localAori.deposit(testOrder, signature, defaultSrcSolverData(testOrder.inputAmount));
 
-        testOrderHash = localAori.hash(testOrder);
+        testOrderHash = keccak256(abi.encode(testOrder));
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -91,7 +91,7 @@ contract AoriLensTests is TestUtils {
             endTime: uint32(block.timestamp + 1 hours),
             srcEid: localEid,
             dstEid: remoteEid,
-            options: Options({ feeMbps: 500, feeRecipient: feeRecipient, solver: optionsSolver, slippageMbps: 100 })
+            options: Options({ feeMbps: 500, slippageMbps: 100, feeRecipient: feeRecipient, srcSolver: optionsSolver, dstSolver: address(0) })
         });
 
         bytes memory signature = signOrder(order);
@@ -100,7 +100,7 @@ contract AoriLensTests is TestUtils {
         vm.prank(solver);
         localAori.deposit(order, signature);
 
-        bytes32 orderHash = localAori.hash(order);
+        bytes32 orderHash = keccak256(abi.encode(order));
         Order memory r = localLens.orders(orderHash);
 
         assertEq(r.inputAmount, order.inputAmount, "inputAmount");
@@ -115,7 +115,8 @@ contract AoriLensTests is TestUtils {
         assertEq(r.recipient, order.recipient, "recipient");
         assertEq(r.options.feeMbps, order.options.feeMbps, "feeMbps");
         assertEq(r.options.feeRecipient, order.options.feeRecipient, "feeRecipient");
-        assertEq(r.options.solver, order.options.solver, "solver");
+        assertEq(r.options.srcSolver, order.options.srcSolver, "srcSolver");
+        assertEq(r.options.dstSolver, order.options.dstSolver, "dstSolver");
         assertEq(r.options.slippageMbps, order.options.slippageMbps, "slippageMbps");
     }
 
@@ -162,7 +163,7 @@ contract AoriLensTests is TestUtils {
         vm.prank(solver);
         localAori.deposit(order2, sig2);
 
-        bytes32 orderHash2 = localAori.hash(order2);
+        bytes32 orderHash2 = keccak256(abi.encode(order2));
 
         // Both orders should be readable
         Order memory retrieved1 = localLens.orders(testOrderHash);
@@ -245,7 +246,7 @@ contract AoriLensTests is TestUtils {
         }
         payload[21] = 0x00;
         payload[22] = 0x01; // 1 fill
-        bytes32 orderHash = localAori.hash(testOrder);
+        bytes32 orderHash = keccak256(abi.encode(testOrder));
         for (uint256 i = 0; i < 32; i++) {
             payload[23 + i] = orderHash[i];
         }
@@ -317,7 +318,7 @@ contract AoriLensTests is TestUtils {
 
         // Check the fill was recorded
         bytes32 fillHash = remoteLens.srcEidToFillerFills(localEid, solver, 0);
-        bytes32 expectedHash = remoteAori.hash(testOrder);
+        bytes32 expectedHash = keccak256(abi.encode(testOrder));
         assertEq(fillHash, expectedHash, "Fill hash should match order hash");
     }
 
@@ -556,7 +557,7 @@ contract AoriLensTests is TestUtils {
             endTime: uint32(block.timestamp + 1 hours),
             srcEid: localEid,
             dstEid: remoteEid,
-            options: Options({ feeMbps: 0, feeRecipient: address(0), solver: address(0), slippageMbps: 0 })
+            options: Options({ feeMbps: 0, slippageMbps: 0, feeRecipient: address(0), srcSolver: address(0), dstSolver: address(0) })
         });
 
         vm.prank(userA);
@@ -658,7 +659,7 @@ contract AoriLensTests is TestUtils {
 
         assertEq(result.length, 1, "Should return 1 array");
         assertEq(result[0].length, 1, "Should have 1 fill");
-        assertEq(result[0][0], remoteAori.hash(testOrder), "Should match order hash");
+        assertEq(result[0][0], keccak256(abi.encode(testOrder)), "Should match order hash");
     }
 
     /**
@@ -693,8 +694,8 @@ contract AoriLensTests is TestUtils {
 
         assertEq(result.length, 1, "Should return 1 array");
         assertEq(result[0].length, 2, "Should have 2 fills");
-        assertEq(result[0][0], remoteAori.hash(testOrder), "First fill should match");
-        assertEq(result[0][1], remoteAori.hash(order2), "Second fill should match");
+        assertEq(result[0][0], keccak256(abi.encode(testOrder)), "First fill should match");
+        assertEq(result[0][1], keccak256(abi.encode(order2)), "Second fill should match");
     }
 
     /**
@@ -723,7 +724,7 @@ contract AoriLensTests is TestUtils {
         assertEq(result[0].length, 1, "First srcEid should have 1 fill");
         assertEq(result[1].length, 0, "Second srcEid should have no fills");
         assertEq(result[2].length, 0, "Third srcEid should have no fills");
-        assertEq(result[0][0], remoteAori.hash(testOrder), "Should match order hash");
+        assertEq(result[0][0], keccak256(abi.encode(testOrder)), "Should match order hash");
     }
 
     /**
@@ -845,7 +846,7 @@ contract AoriLensTests is TestUtils {
         vm.prank(solver);
         localAori.deposit(order2, sig2, defaultSrcSolverData(order2.inputAmount));
 
-        bytes32 orderHash2 = localAori.hash(order2);
+        bytes32 orderHash2 = keccak256(abi.encode(order2));
 
         bytes32[] memory orderHashes = new bytes32[](2);
         orderHashes[0] = testOrderHash;
@@ -889,7 +890,7 @@ contract AoriLensTests is TestUtils {
         vm.prank(solver);
         localAori.deposit(order2, sig2);
 
-        bytes32 orderHash2 = localAori.hash(order2);
+        bytes32 orderHash2 = keccak256(abi.encode(order2));
 
         bytes32[] memory orderHashes = new bytes32[](2);
         orderHashes[0] = testOrderHash;
@@ -974,7 +975,7 @@ contract AoriLensTests is TestUtils {
             vm.prank(solver);
             localAori.deposit(order, sig, defaultSrcSolverData(order.inputAmount));
 
-            orderHashes[i] = localAori.hash(order);
+            orderHashes[i] = keccak256(abi.encode(order));
             expectedTotal += order.inputAmount;
         }
 

--- a/test/foundry/37_AoriLensTests.t.sol
+++ b/test/foundry/37_AoriLensTests.t.sol
@@ -78,7 +78,12 @@ contract AoriLensTests is TestUtils {
     function testOrders_AllFieldsCorrect() public {
         address distinctRecipient = address(0xBBBB);
         address feeRecipient = address(0xCCCC);
-        address optionsSolver = solver;
+        address srcSolverAddr = solver;
+        address dstSolverAddr = address(0xDDDD);
+
+        // Whitelist dstSolver so the order is valid
+        vm.prank(localAori.owner());
+        localAori.addAllowedSolver(dstSolverAddr);
 
         Order memory order = Order({
             offerer: userA,
@@ -91,7 +96,13 @@ contract AoriLensTests is TestUtils {
             endTime: uint32(block.timestamp + 1 hours),
             srcEid: localEid,
             dstEid: remoteEid,
-            options: Options({ feeMbps: 500, slippageMbps: 100, feeRecipient: feeRecipient, srcSolver: optionsSolver, dstSolver: address(0) })
+            options: Options({
+                feeMbps: 500,
+                slippageMbps: 100,
+                feeRecipient: feeRecipient,
+                srcSolver: srcSolverAddr,
+                dstSolver: dstSolverAddr
+            })
         });
 
         bytes memory signature = signOrder(order);
@@ -117,6 +128,7 @@ contract AoriLensTests is TestUtils {
         assertEq(r.options.feeRecipient, order.options.feeRecipient, "feeRecipient");
         assertEq(r.options.srcSolver, order.options.srcSolver, "srcSolver");
         assertEq(r.options.dstSolver, order.options.dstSolver, "dstSolver");
+        assertTrue(r.options.dstSolver != address(0), "dstSolver should be non-zero to validate slot 7 read");
         assertEq(r.options.slippageMbps, order.options.slippageMbps, "slippageMbps");
     }
 
@@ -175,6 +187,27 @@ contract AoriLensTests is TestUtils {
         assertEq(retrieved2.offerer, userA, "Order 2 offerer mismatch");
         assertEq(retrieved2.recipient, distinctRecipient, "Order 2 recipient mismatch");
         assertTrue(retrieved2.offerer != retrieved2.recipient, "offerer and recipient must differ to validate slot reads");
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                      hash() TESTS                           */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /**
+     * @notice Test hash() returns keccak256(abi.encode(order))
+     */
+    function testHash_MatchesKeccak() public view {
+        bytes32 lensHash = localLens.hash(testOrder);
+        bytes32 expected = keccak256(abi.encode(testOrder));
+        assertEq(lensHash, expected, "Lens hash should match keccak256(abi.encode(order))");
+    }
+
+    /**
+     * @notice Test hash() matches the order ID used during deposit
+     */
+    function testHash_MatchesDepositOrderId() public view {
+        bytes32 lensHash = localLens.hash(testOrder);
+        assertEq(lensHash, testOrderHash, "Lens hash should match deposit order ID");
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/

--- a/test/foundry/3_CancellationTests.t.sol
+++ b/test/foundry/3_CancellationTests.t.sol
@@ -109,7 +109,7 @@ contract CancellationTests is TestUtils {
         // Create order with different srcEid
         Order memory order = createSingleChainOrder();
         order.srcEid = remoteEid; // Different from current chain
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         vm.prank(solver);
         vm.expectRevert(NotOnSourceChain.selector);
@@ -132,7 +132,7 @@ contract CancellationTests is TestUtils {
         vm.prank(solver);
         localAori.deposit(order, signature);
 
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         // Cancel it first to make it inactive
         vm.prank(solver);
@@ -159,7 +159,7 @@ contract CancellationTests is TestUtils {
         vm.prank(solver);
         localAori.deposit(order, signature);
 
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         vm.prank(solver);
         vm.expectRevert(CrossChainOrdersMustBeCancelledFromDestinationChain.selector);
@@ -181,7 +181,7 @@ contract CancellationTests is TestUtils {
         vm.prank(solver);
         localAori.deposit(order, signature);
 
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         // Random user tries to cancel before expiry
         address randomUser = makeAddr("random");
@@ -205,7 +205,7 @@ contract CancellationTests is TestUtils {
         vm.prank(solver);
         localAori.deposit(order, signature);
 
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         // Advance time past expiry
         vm.warp(order.endTime + 1);
@@ -233,7 +233,7 @@ contract CancellationTests is TestUtils {
         vm.prank(solver);
         localAori.deposit(order, signature);
 
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         // Solver can cancel before expiry
         vm.prank(solver);
@@ -258,7 +258,7 @@ contract CancellationTests is TestUtils {
         vm.prank(solver);
         localAori.deposit(order, signature);
 
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         // Drain contract balance
         uint256 contractBalance = inputToken.balanceOf(payable(address(localAori)));
@@ -284,7 +284,7 @@ contract CancellationTests is TestUtils {
 
         // Create order and modify it to create hash mismatch
         Order memory order = createCrossChainOrder();
-        bytes32 orderId = remoteAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         // Modify order to create mismatch
         order.inputAmount = uint128(2e18);
@@ -305,7 +305,7 @@ contract CancellationTests is TestUtils {
         // Create cross-chain order but try to cancel from wrong chain
         Order memory order = createCrossChainOrder();
         order.dstEid = localEid; // This would cause LayerZero NoPeer error
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
         bytes memory options = OptionsBuilder.newOptions().addExecutorLzReceiveOption(200000, 0);
 
         vm.prank(solver);
@@ -321,7 +321,7 @@ contract CancellationTests is TestUtils {
 
         // Create order and set it to Cancelled status on destination chain
         Order memory order = createCrossChainOrder();
-        bytes32 orderId = remoteAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
         bytes memory options = OptionsBuilder.newOptions().addExecutorLzReceiveOption(200000, 0);
 
         // First cancel the order to set it to Cancelled status
@@ -345,7 +345,7 @@ contract CancellationTests is TestUtils {
         vm.chainId(remoteEid);
 
         Order memory order = createCrossChainOrder();
-        bytes32 orderId = remoteAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
         bytes memory options = OptionsBuilder.newOptions().addExecutorLzReceiveOption(200000, 0);
 
         address randomUser = makeAddr("random");
@@ -361,7 +361,7 @@ contract CancellationTests is TestUtils {
         vm.chainId(remoteEid);
 
         Order memory order = createCrossChainOrder();
-        bytes32 orderId = remoteAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
         bytes memory options = OptionsBuilder.newOptions().addExecutorLzReceiveOption(200000, 0);
 
         // Advance time past expiry
@@ -386,7 +386,7 @@ contract CancellationTests is TestUtils {
         Order memory order = createCrossChainOrder();
         address recipient = makeAddr("recipient");
         order.recipient = recipient;
-        bytes32 orderId = remoteAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
         bytes memory options = OptionsBuilder.newOptions().addExecutorLzReceiveOption(200000, 0);
 
         // Advance time past expiry
@@ -409,7 +409,7 @@ contract CancellationTests is TestUtils {
         vm.chainId(remoteEid);
 
         Order memory order = createCrossChainOrder();
-        bytes32 orderId = remoteAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
         bytes memory options = OptionsBuilder.newOptions().addExecutorLzReceiveOption(200000, 0);
 
         uint256 cancelFee = remoteAori.quote(localEid, 1, options, false, localEid, solver).nativeFee;
@@ -482,7 +482,7 @@ contract CancellationTests is TestUtils {
         vm.prank(solver);
         localAori.deposit(order, signature);
 
-        bytes32 orderHash = localAori.hash(order);
+        bytes32 orderHash = keccak256(abi.encode(order));
 
         // PHASE 2: Cancel from destination chain
         vm.chainId(remoteEid);
@@ -533,7 +533,7 @@ contract CancellationTests is TestUtils {
         vm.prank(solver);
         localAori.deposit(order, signature);
 
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         // Pause contract
         vm.prank(address(this));
@@ -555,7 +555,7 @@ contract CancellationTests is TestUtils {
         remoteAori.pause();
 
         Order memory order = createCrossChainOrder();
-        bytes32 orderId = remoteAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
         bytes memory options = OptionsBuilder.newOptions().addExecutorLzReceiveOption(200000, 0);
 
         vm.prank(solver);
@@ -577,7 +577,7 @@ contract CancellationTests is TestUtils {
         vm.prank(solver);
         localAori.deposit(order, signature);
 
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         // Test exactly at expiry time (should fail)
         vm.warp(order.endTime);
@@ -601,7 +601,7 @@ contract CancellationTests is TestUtils {
         vm.prank(solver);
         localAori.deposit(order, signature);
 
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         // Test one second after expiry (should succeed)
         vm.warp(order.endTime + 1);

--- a/test/foundry/4_Deposit.t.sol
+++ b/test/foundry/4_Deposit.t.sol
@@ -52,7 +52,7 @@ contract DepositTests is TestUtils {
         assertEq(localLens.getLockedBalances(userA, address(inputToken)), initialLocked + order.inputAmount);
         assertEq(inputToken.balanceOf(userA), initialBalance - order.inputAmount);
 
-        bytes32 orderHash = localAori.hash(order);
+        bytes32 orderHash = keccak256(abi.encode(order));
         assertEq(uint8(localAori.orderStatus(orderHash)), uint8(OrderStatus.Active));
     }
 
@@ -75,7 +75,7 @@ contract DepositTests is TestUtils {
         // Verify locked balance increased
         assertEq(localLens.getLockedBalances(userA, address(inputToken)), initialLocked + order.inputAmount);
 
-        bytes32 orderHash = localAori.hash(order);
+        bytes32 orderHash = keccak256(abi.encode(order));
         assertEq(uint8(localAori.orderStatus(orderHash)), uint8(OrderStatus.Active));
     }
 
@@ -421,7 +421,7 @@ contract DepositTests is TestUtils {
     function testDeposit_EmitsEvents() public {
         Order memory order = createValidTestOrder();
         bytes memory signature = signOrder(order);
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         vm.prank(userA);
         inputToken.approve(address(localAori), order.inputAmount);
@@ -450,7 +450,7 @@ contract DepositTests is TestUtils {
         vm.prank(solver);
         localAori.deposit(order, signature);
 
-        bytes32 orderHash = localAori.hash(order);
+        bytes32 orderHash = keccak256(abi.encode(order));
         assertEq(uint8(localAori.orderStatus(orderHash)), uint8(OrderStatus.Active));
     }
 
@@ -468,7 +468,7 @@ contract DepositTests is TestUtils {
         vm.prank(solver);
         localAori.deposit(order, signature);
 
-        bytes32 orderHash = localAori.hash(order);
+        bytes32 orderHash = keccak256(abi.encode(order));
         assertEq(uint8(localAori.orderStatus(orderHash)), uint8(OrderStatus.Active));
     }
 
@@ -491,7 +491,7 @@ contract DepositTests is TestUtils {
         vm.prank(solver);
         localAori.deposit(order, signature);
 
-        bytes32 orderHash = localAori.hash(order);
+        bytes32 orderHash = keccak256(abi.encode(order));
         assertEq(uint8(localAori.orderStatus(orderHash)), uint8(OrderStatus.Active));
     }
 

--- a/test/foundry/6_FillFail.t.sol
+++ b/test/foundry/6_FillFail.t.sol
@@ -160,7 +160,7 @@ contract FillFailTest is TestUtils {
         remoteAori.fill(order);
 
         // Verify order status
-        bytes32 orderHash = remoteAori.hash(order);
+        bytes32 orderHash = keccak256(abi.encode(order));
         assertEq(uint8(remoteAori.orderStatus(orderHash)), uint8(OrderStatus.Filled), "Order should be in filled state");
     }
 

--- a/test/foundry/7_SettlementTests.t.sol
+++ b/test/foundry/7_SettlementTests.t.sol
@@ -312,28 +312,29 @@ contract SettlementTests is TestUtils {
         // Hash the nested Options struct first
         bytes32 optionsHash = keccak256(
             abi.encode(
-                keccak256("Options(uint16 feeMbps,address feeRecipient,address solver,uint16 slippageMbps)"),
+                keccak256("Options(uint16 feeMbps,uint16 slippageMbps,address feeRecipient,address srcSolver,address dstSolver)"),
                 order.options.feeMbps,
+                order.options.slippageMbps,
                 order.options.feeRecipient,
-                order.options.solver,
-                order.options.slippageMbps
+                order.options.srcSolver,
+                order.options.dstSolver
             )
         );
 
         bytes32 structHash = keccak256(
             abi.encode(
                 keccak256(
-                    "Order(uint128 inputAmount,uint128 outputAmount,address inputToken,address outputToken,"
-                    "uint32 startTime,uint32 endTime,uint32 srcEid,uint32 dstEid,address offerer,address recipient," "Options options)"
-                    "Options(uint16 feeMbps,address feeRecipient,address solver,uint16 slippageMbps)"
+                    "Order(uint128 inputAmount,uint128 outputAmount,address inputToken,"
+                    "uint32 startTime,uint32 endTime,uint32 srcEid,address outputToken,uint32 dstEid,address offerer,address recipient," "Options options)"
+                    "Options(uint16 feeMbps,uint16 slippageMbps,address feeRecipient,address srcSolver,address dstSolver)"
                 ),
                 order.inputAmount,
                 order.outputAmount,
                 order.inputToken,
-                order.outputToken,
                 order.startTime,
                 order.endTime,
                 order.srcEid,
+                order.outputToken,
                 order.dstEid,
                 order.offerer,
                 order.recipient,

--- a/test/foundry/9_ValidationFailure.t.sol
+++ b/test/foundry/9_ValidationFailure.t.sol
@@ -186,7 +186,7 @@ contract ValidationFailuresTest is TestUtils {
         remoteAori.fill(order);
 
         // Verify order status
-        bytes32 orderHash = remoteAori.hash(order);
+        bytes32 orderHash = keccak256(abi.encode(order));
         assertEq(uint8(remoteAori.orderStatus(orderHash)), uint8(OrderStatus.Filled), "Order should be in filled state");
     }
 

--- a/test/foundry/CC_ERC20ToNativeDstHook.t.sol
+++ b/test/foundry/CC_ERC20ToNativeDstHook.t.sol
@@ -246,7 +246,7 @@ contract CC_ERC20ToNativeDstHook is TestUtils {
             uint8(0), // message type 0 for settlement
             solverSource, // filler address (should be source chain solver for settlement)
             uint16(1), // fill count
-            localAori.hash(order) // order hash
+            keccak256(abi.encode(order)) // order hash
         );
 
         vm.prank(address(endpoints[localEid]));
@@ -279,7 +279,7 @@ contract CC_ERC20ToNativeDstHook is TestUtils {
         assertEq(inputToken.balanceOf(userSource), initialUserBalance - INPUT_AMOUNT, "User balance should decrease");
 
         // Verify order status
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Active, "Order should be Active");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Active, "Order should be Active");
     }
 
     /**
@@ -318,7 +318,7 @@ contract CC_ERC20ToNativeDstHook is TestUtils {
         );
 
         // Verify order status
-        assertTrue(remoteAori.orderStatus(localAori.hash(order)) == OrderStatus.Filled, "Order should be Filled");
+        assertTrue(remoteAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Filled, "Order should be Filled");
     }
 
     /**
@@ -348,7 +348,7 @@ contract CC_ERC20ToNativeDstHook is TestUtils {
         );
 
         // Verify order status
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Settled, "Order should be Settled");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Settled, "Order should be Settled");
 
         // Verify locked balance is cleared
         assertEq(localLens.getLockedBalances(userSource, address(inputToken)), 0, "Offerer should have no locked balance after settlement");

--- a/test/foundry/CC_ERC20ToNativeHook.t.sol
+++ b/test/foundry/CC_ERC20ToNativeHook.t.sol
@@ -268,7 +268,7 @@ contract CC_ERC20ToNativeHook is TestUtils {
             uint8(0), // message type 0 for settlement
             solverSource, // filler address (should be source chain solver for settlement)
             uint16(1), // fill count
-            localAori.hash(order) // order hash
+            keccak256(abi.encode(order)) // order hash
         );
 
         vm.prank(address(endpoints[localEid]));
@@ -305,7 +305,7 @@ contract CC_ERC20ToNativeHook is TestUtils {
         );
 
         // Verify order status
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Active, "Order should be Active");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Active, "Order should be Active");
     }
 
     /**
@@ -342,7 +342,7 @@ contract CC_ERC20ToNativeHook is TestUtils {
         );
 
         // Verify order status
-        assertTrue(remoteAori.orderStatus(localAori.hash(order)) == OrderStatus.Filled, "Order should be Filled");
+        assertTrue(remoteAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Filled, "Order should be Filled");
     }
 
     /**
@@ -372,7 +372,7 @@ contract CC_ERC20ToNativeHook is TestUtils {
         );
 
         // Verify order status
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Settled, "Order should be Settled");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Settled, "Order should be Settled");
 
         // Verify locked balance is cleared
         assertEq(

--- a/test/foundry/CC_ERC20ToNativeNoHook.t.sol
+++ b/test/foundry/CC_ERC20ToNativeNoHook.t.sol
@@ -189,7 +189,7 @@ contract CC_ERC20ToNativeNoHook is TestUtils {
             uint8(0), // message type 0 for settlement
             solverSource, // filler address (should be source chain solver for settlement)
             uint16(1), // fill count
-            localAori.hash(order) // order hash
+            keccak256(abi.encode(order)) // order hash
         );
 
         vm.prank(address(endpoints[localEid]));
@@ -222,7 +222,7 @@ contract CC_ERC20ToNativeNoHook is TestUtils {
         assertEq(inputToken.balanceOf(userSource), initialUserBalance - INPUT_AMOUNT, "User balance should decrease");
 
         // Verify order status
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Active, "Order should be Active");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Active, "Order should be Active");
     }
 
     /**
@@ -245,7 +245,7 @@ contract CC_ERC20ToNativeNoHook is TestUtils {
         assertEq(address(remoteAori).balance, preFillContractNative, "Contract should not hold native tokens after direct fill");
 
         // Verify order status
-        assertTrue(remoteAori.orderStatus(localAori.hash(order)) == OrderStatus.Filled, "Order should be Filled");
+        assertTrue(remoteAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Filled, "Order should be Filled");
     }
 
     /**
@@ -275,7 +275,7 @@ contract CC_ERC20ToNativeNoHook is TestUtils {
         );
 
         // Verify order status
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Settled, "Order should be Settled");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Settled, "Order should be Settled");
 
         // Verify locked balance is cleared
         assertEq(localLens.getLockedBalances(userSource, address(inputToken)), 0, "Offerer should have no locked balance after settlement");

--- a/test/foundry/CC_ERC20ToNativeSrcHook.t.sol
+++ b/test/foundry/CC_ERC20ToNativeSrcHook.t.sol
@@ -215,7 +215,7 @@ contract CC_ERC20ToNativeSrcHook is TestUtils {
             uint8(0), // message type 0 for settlement
             solverSource, // filler address (should be source chain solver for settlement)
             uint16(1), // fill count
-            localAori.hash(order) // order hash
+            keccak256(abi.encode(order)) // order hash
         );
 
         vm.prank(address(endpoints[localEid]));
@@ -252,7 +252,7 @@ contract CC_ERC20ToNativeSrcHook is TestUtils {
         assertEq(inputToken.balanceOf(userSource), initialUserBalance - INPUT_AMOUNT, "User balance should decrease");
 
         // Verify order status
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Active, "Order should be Active");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Active, "Order should be Active");
     }
 
     /**
@@ -275,7 +275,7 @@ contract CC_ERC20ToNativeSrcHook is TestUtils {
         assertEq(address(remoteAori).balance, preFillContractNative, "Contract should not hold native tokens after direct fill");
 
         // Verify order status
-        assertTrue(remoteAori.orderStatus(localAori.hash(order)) == OrderStatus.Filled, "Order should be Filled");
+        assertTrue(remoteAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Filled, "Order should be Filled");
     }
 
     /**
@@ -305,7 +305,7 @@ contract CC_ERC20ToNativeSrcHook is TestUtils {
         );
 
         // Verify order status
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Settled, "Order should be Settled");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Settled, "Order should be Settled");
 
         // Verify locked balance is cleared
         assertEq(

--- a/test/foundry/CC_NativeHookToDirectFill.t.sol
+++ b/test/foundry/CC_NativeHookToDirectFill.t.sol
@@ -220,7 +220,7 @@ contract CC_NativeHookToDirectFill_Test is TestUtils {
             uint8(0), // message type 0 for settlement
             solverSource, // filler address (should be source chain solver for settlement)
             uint16(1), // fill count
-            localAori.hash(order) // order hash
+            keccak256(abi.encode(order)) // order hash
         );
 
         vm.prank(address(endpoints[localEid]));
@@ -248,7 +248,7 @@ contract CC_NativeHookToDirectFill_Test is TestUtils {
         );
 
         // Verify order status
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Active, "Order should be Active");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Active, "Order should be Active");
     }
 
     /**
@@ -269,7 +269,7 @@ contract CC_NativeHookToDirectFill_Test is TestUtils {
         assertEq(outputToken.balanceOf(solverDest), initialSolverOutput - OUTPUT_AMOUNT, "Solver should spend output tokens");
 
         // Verify order status
-        assertTrue(remoteAori.orderStatus(localAori.hash(order)) == OrderStatus.Filled, "Order should be Filled");
+        assertTrue(remoteAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Filled, "Order should be Filled");
     }
 
     /**
@@ -283,7 +283,7 @@ contract CC_NativeHookToDirectFill_Test is TestUtils {
 
         // Verify order status on source chain
         vm.chainId(localEid);
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Settled, "Order should be Settled");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Settled, "Order should be Settled");
 
         // Verify locked balance is cleared
         assertEq(localLens.getLockedBalances(userSource, address(convertedToken)), 0, "User should have no locked balance after settlement");
@@ -372,7 +372,7 @@ contract CC_NativeHookToDirectFill_Test is TestUtils {
         console.log("");
 
         // Verify deposit state
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Active, "Order should be Active");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Active, "Order should be Active");
 
         // === PHASE 2: FILL DIRECTLY (NO HOOK) ===
         console.log("=== PHASE 2: SOLVER FILLS DIRECTLY ON DESTINATION (NO HOOK) ===");
@@ -390,7 +390,7 @@ contract CC_NativeHookToDirectFill_Test is TestUtils {
         console.log("");
 
         // Verify fill state
-        assertTrue(remoteAori.orderStatus(localAori.hash(order)) == OrderStatus.Filled, "Order should be Filled");
+        assertTrue(remoteAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Filled, "Order should be Filled");
 
         // === PHASE 3: SETTLEMENT ===
         console.log("=== PHASE 3: SETTLEMENT VIA LAYERZERO ===");
@@ -407,7 +407,7 @@ contract CC_NativeHookToDirectFill_Test is TestUtils {
         console.log("");
 
         // Verify settlement state
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Settled, "Order should be Settled");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Settled, "Order should be Settled");
 
         // === PHASE 4: WITHDRAWAL ===
         console.log("=== PHASE 4: SOLVER WITHDRAWS EARNED TOKENS ===");

--- a/test/foundry/CC_NativeHookToHookFill.t.sol
+++ b/test/foundry/CC_NativeHookToHookFill.t.sol
@@ -271,7 +271,7 @@ contract CC_NativeHookToHookFill_Test is TestUtils {
             uint8(0), // message type 0 for settlement
             solverSource, // filler address (should be source chain solver for settlement)
             uint16(1), // fill count
-            localAori.hash(order) // order hash
+            keccak256(abi.encode(order)) // order hash
         );
 
         vm.prank(address(endpoints[localEid]));
@@ -297,7 +297,7 @@ contract CC_NativeHookToHookFill_Test is TestUtils {
         );
 
         // Verify order status
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Active, "Order should be Active");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Active, "Order should be Active");
     }
 
     /**
@@ -325,7 +325,7 @@ contract CC_NativeHookToHookFill_Test is TestUtils {
         );
 
         // Verify order status
-        assertTrue(remoteAori.orderStatus(localAori.hash(order)) == OrderStatus.Filled, "Order should be Filled");
+        assertTrue(remoteAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Filled, "Order should be Filled");
     }
 
     /**
@@ -339,7 +339,7 @@ contract CC_NativeHookToHookFill_Test is TestUtils {
 
         // Verify order status on source chain
         vm.chainId(localEid);
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Settled, "Order should be Settled");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Settled, "Order should be Settled");
 
         // Verify locked balance is cleared
         assertEq(localLens.getLockedBalances(userSource, address(convertedToken)), 0, "User should have no locked balance after settlement");
@@ -422,7 +422,7 @@ contract CC_NativeHookToHookFill_Test is TestUtils {
         console.log("  srcHook conversion: 1 ETH -> 1500 converted tokens");
         console.log("");
 
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Active, "Order should be Active");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Active, "Order should be Active");
 
         // === PHASE 2: FILL WITH DSTHOOK ===
         console.log("=== PHASE 2: SOLVER FILLS WITH DSTHOOK ===");
@@ -441,7 +441,7 @@ contract CC_NativeHookToHookFill_Test is TestUtils {
         console.log("  User received: 1 ETH, Surplus to solver: 0.1 ETH");
         console.log("");
 
-        assertTrue(remoteAori.orderStatus(localAori.hash(order)) == OrderStatus.Filled, "Order should be Filled");
+        assertTrue(remoteAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Filled, "Order should be Filled");
 
         // === PHASE 3: SETTLEMENT ===
         console.log("=== PHASE 3: SETTLEMENT VIA LAYERZERO ===");
@@ -457,7 +457,7 @@ contract CC_NativeHookToHookFill_Test is TestUtils {
         console.log("  Solver unlocked tokens:", afterSettleUnlockedTokens / 1e18, "tokens");
         console.log("");
 
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Settled, "Order should be Settled");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Settled, "Order should be Settled");
 
         // === PHASE 4: WITHDRAWAL ===
         console.log("=== PHASE 4: SOLVER WITHDRAWS EARNED TOKENS ===");

--- a/test/foundry/CC_NativeToERC20NoHook.t.sol
+++ b/test/foundry/CC_NativeToERC20NoHook.t.sol
@@ -189,7 +189,7 @@ contract CC_NativeToERC20NoHook is TestUtils {
             uint8(0), // message type 0 for settlement
             solverSource, // filler address (should be source chain solver for settlement)
             uint16(1), // fill count
-            localAori.hash(order) // order hash
+            keccak256(abi.encode(order)) // order hash
         );
 
         vm.prank(address(endpoints[localEid]));
@@ -220,7 +220,7 @@ contract CC_NativeToERC20NoHook is TestUtils {
         assertEq(userSource.balance, initialUserBalance - INPUT_AMOUNT, "User balance should decrease");
 
         // Verify order status
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Active, "Order should be Active");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Active, "Order should be Active");
     }
 
     /**
@@ -247,7 +247,7 @@ contract CC_NativeToERC20NoHook is TestUtils {
         );
 
         // Verify order status
-        assertTrue(remoteAori.orderStatus(localAori.hash(order)) == OrderStatus.Filled, "Order should be Filled");
+        assertTrue(remoteAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Filled, "Order should be Filled");
     }
 
     /**
@@ -277,7 +277,7 @@ contract CC_NativeToERC20NoHook is TestUtils {
         );
 
         // Verify order status
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Settled, "Order should be Settled");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Settled, "Order should be Settled");
 
         // Verify locked balance is cleared
         assertEq(localLens.getLockedBalances(userSource, NATIVE_TOKEN), 0, "Offerer should have no locked balance after settlement");

--- a/test/foundry/CC_NativeToERC20dstHook.t.sol
+++ b/test/foundry/CC_NativeToERC20dstHook.t.sol
@@ -218,7 +218,7 @@ contract CC_NativeToERC20DstHook is TestUtils {
             uint8(0), // message type 0 for settlement
             solverSource, // filler address (should be source chain solver for settlement)
             uint16(1), // fill count
-            localAori.hash(order) // order hash
+            keccak256(abi.encode(order)) // order hash
         );
 
         vm.prank(address(endpoints[localEid]));
@@ -249,7 +249,7 @@ contract CC_NativeToERC20DstHook is TestUtils {
         assertEq(userSource.balance, initialUserBalance - INPUT_AMOUNT, "User balance should decrease");
 
         // Verify order status
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Active, "Order should be Active");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Active, "Order should be Active");
     }
 
     /**
@@ -292,7 +292,7 @@ contract CC_NativeToERC20DstHook is TestUtils {
         );
 
         // Verify order status
-        assertTrue(remoteAori.orderStatus(localAori.hash(order)) == OrderStatus.Filled, "Order should be Filled");
+        assertTrue(remoteAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Filled, "Order should be Filled");
     }
 
     /**
@@ -322,7 +322,7 @@ contract CC_NativeToERC20DstHook is TestUtils {
         );
 
         // Verify order status
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Settled, "Order should be Settled");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Settled, "Order should be Settled");
 
         // Verify locked balance is cleared
         assertEq(localLens.getLockedBalances(userSource, NATIVE_TOKEN), 0, "Offerer should have no locked balance after settlement");

--- a/test/foundry/CC_NativeToNativeHook.t.sol
+++ b/test/foundry/CC_NativeToNativeHook.t.sol
@@ -212,7 +212,7 @@ contract CC_NativeToNativeHook is TestUtils {
             uint8(0), // message type 0 for settlement
             solverSource, // filler address (should be source chain solver for settlement)
             uint16(1), // fill count
-            localAori.hash(order) // order hash
+            keccak256(abi.encode(order)) // order hash
         );
 
         vm.prank(address(endpoints[localEid]));
@@ -239,7 +239,7 @@ contract CC_NativeToNativeHook is TestUtils {
         assertEq(address(localAori).balance, initialContractBalance + INPUT_AMOUNT, "Contract should receive native tokens");
 
         // Verify order status
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Active, "Order should be Active");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Active, "Order should be Active");
     }
 
     /**
@@ -279,7 +279,7 @@ contract CC_NativeToNativeHook is TestUtils {
         );
 
         // Verify order status
-        assertTrue(remoteAori.orderStatus(localAori.hash(order)) == OrderStatus.Filled, "Order should be Filled");
+        assertTrue(remoteAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Filled, "Order should be Filled");
     }
 
     /**
@@ -309,7 +309,7 @@ contract CC_NativeToNativeHook is TestUtils {
         );
 
         // Verify order status
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Settled, "Order should be Settled");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Settled, "Order should be Settled");
 
         // Verify locked balance is cleared
         assertEq(localLens.getLockedBalances(userSource, NATIVE_TOKEN), 0, "Offerer should have no locked balance after settlement");

--- a/test/foundry/CC_NativeToNativeNoHook.t.sol
+++ b/test/foundry/CC_NativeToNativeNoHook.t.sol
@@ -152,7 +152,7 @@ contract CC_NativeToNativeNoHook is TestUtils {
             uint8(0), // message type 0 for settlement
             solverSource, // filler address (should be source chain solver for settlement)
             uint16(1), // fill count
-            localAori.hash(order) // order hash
+            keccak256(abi.encode(order)) // order hash
         );
 
         vm.prank(address(endpoints[localEid]));
@@ -179,7 +179,7 @@ contract CC_NativeToNativeNoHook is TestUtils {
         assertEq(address(localAori).balance, initialContractBalance + INPUT_AMOUNT, "Contract should receive native tokens");
 
         // Verify order status
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Active, "Order should be Active");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Active, "Order should be Active");
     }
 
     /**
@@ -201,7 +201,7 @@ contract CC_NativeToNativeNoHook is TestUtils {
         assertEq(address(remoteAori).balance, preFillContractNative, "Contract balance should remain unchanged (direct transfer)");
 
         // Verify order status
-        assertTrue(remoteAori.orderStatus(localAori.hash(order)) == OrderStatus.Filled, "Order should be Filled");
+        assertTrue(remoteAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Filled, "Order should be Filled");
     }
 
     /**
@@ -231,7 +231,7 @@ contract CC_NativeToNativeNoHook is TestUtils {
         );
 
         // Verify order status
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Settled, "Order should be Settled");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Settled, "Order should be Settled");
 
         // Verify locked balance is cleared
         assertEq(localLens.getLockedBalances(userSource, NATIVE_TOKEN), 0, "Offerer should have no locked balance after settlement");
@@ -449,6 +449,6 @@ contract CC_NativeToNativeNoHook is TestUtils {
         assertEq(userDest.balance, initialUserBalance + OUTPUT_AMOUNT, "User should receive output amount");
 
         // Verify order status
-        assertTrue(remoteAori.orderStatus(localAori.hash(order)) == OrderStatus.Filled, "Order should be Filled");
+        assertTrue(remoteAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Filled, "Order should be Filled");
     }
 }

--- a/test/foundry/FeeOnTransferGuard.t.sol
+++ b/test/foundry/FeeOnTransferGuard.t.sol
@@ -81,7 +81,7 @@ contract FeeOnTransferGuard_Test is TestUtils {
         vm.prank(solver);
         localAori.deposit(order, signature);
 
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
         assertTrue(localAori.orderStatus(orderId) == OrderStatus.Active, "Order should be Active");
         assertEq(localLens.getLockedBalances(userA, address(inputToken)), INPUT_AMOUNT, "Locked balance should match input amount");
     }
@@ -154,7 +154,7 @@ contract FeeOnTransferGuard_Test is TestUtils {
         vm.prank(solver);
         localAori.fill(order);
 
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
         assertTrue(localAori.orderStatus(orderId) == OrderStatus.Settled, "Order should be Settled");
         assertEq(outputToken.balanceOf(userA), OUTPUT_AMOUNT, "User should receive full output amount");
     }

--- a/test/foundry/SC_ERC20ToNativeDstHook.t.sol
+++ b/test/foundry/SC_ERC20ToNativeDstHook.t.sol
@@ -194,7 +194,7 @@ contract SC_ERC20ToNativeDstHook_Test is TestUtils {
         );
 
         bytes memory signature = signOrder(order, userSCPrivKey);
-        orderId = localAori.hash(order);
+        orderId = keccak256(abi.encode(order));
 
         // User approves and deposits (no hook)
         vm.prank(userSC);
@@ -378,7 +378,7 @@ contract SC_ERC20ToNativeDstHook_Test is TestUtils {
         );
 
         bytes memory signature = signOrder(testOrder, 0x9999 + scenarioSalt);
-        bytes32 orderId = localAori.hash(testOrder);
+        bytes32 orderId = keccak256(abi.encode(testOrder));
 
         // Phase 1: Deposit
         vm.prank(testUser);
@@ -464,7 +464,7 @@ contract SC_ERC20ToNativeDstHook_Test is TestUtils {
         );
 
         bytes memory signature = signOrder(order, userSCPrivKey);
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         // Phase 1: User deposits
         vm.prank(userSC);
@@ -523,7 +523,7 @@ contract SC_ERC20ToNativeDstHook_Test is TestUtils {
         );
 
         bytes memory signature = signOrder(order, userSCPrivKey);
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         // Initial: Unknown
         assertTrue(localAori.orderStatus(orderId) == OrderStatus.Unknown, "Order should start as Unknown");
@@ -571,7 +571,7 @@ contract SC_ERC20ToNativeDstHook_Test is TestUtils {
         );
 
         bytes memory signature = signOrder(order, userSCPrivKey);
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         // Phase 1: Deposit should emit Deposit event
         vm.prank(userSC);

--- a/test/foundry/SC_ERC20ToNativeHook.t.sol
+++ b/test/foundry/SC_ERC20ToNativeHook.t.sol
@@ -184,7 +184,7 @@ contract SC_ERC20ToNativeHook_Test is TestUtils {
         );
 
         // Verify order status is Settled (atomic settlement for single-chain with hook)
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Settled, "Order should be Settled");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Settled, "Order should be Settled");
     }
 
     /**
@@ -266,7 +266,7 @@ contract SC_ERC20ToNativeHook_Test is TestUtils {
         console.log("");
 
         // Verify final state
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Settled, "Order should be Settled");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Settled, "Order should be Settled");
 
         // Verify no locked balances remain (atomic settlement)
         assertEq(localLens.getLockedBalances(userSC, address(inputToken)), 0, "User should have no locked balance after atomic settlement");
@@ -286,7 +286,7 @@ contract SC_ERC20ToNativeHook_Test is TestUtils {
         assertEq(localLens.getLockedBalances(userSC, address(inputToken)), 0);
 
         // Order should be immediately settled
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Settled, "Order should be Settled");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Settled, "Order should be Settled");
     }
 
     /**
@@ -327,7 +327,7 @@ contract SC_ERC20ToNativeHook_Test is TestUtils {
         );
 
         bytes memory signature = signOrder(order, userSCPrivKey);
-        bytes32 expectedOrderId = localAori.hash(order);
+        bytes32 expectedOrderId = keccak256(abi.encode(order));
 
         SrcHook memory srcHook = SrcHook({
             hookAddress: address(mockHook2),
@@ -456,7 +456,7 @@ contract SC_ERC20ToNativeHook_Test is TestUtils {
         _createAndExecuteDepositWithHook();
 
         // Verify order was settled atomically (not just filled)
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Settled, "Single-chain swap should be immediately settled");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Settled, "Single-chain swap should be immediately settled");
 
         // Verify no locked balances remain (atomic settlement)
         // For single-chain swaps with deposit hooks, no balance accounting is used
@@ -475,7 +475,7 @@ contract SC_ERC20ToNativeHook_Test is TestUtils {
         // Execute first swap
         _createAndExecuteDepositWithHook();
         assertTrue(
-            localAori.orderStatus(localAori.hash(order)) == OrderStatus.Settled, "First single-chain swap should be immediately settled"
+            localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Settled, "First single-chain swap should be immediately settled"
         );
 
         // Setup and execute second swap with different amounts
@@ -514,8 +514,8 @@ contract SC_ERC20ToNativeHook_Test is TestUtils {
         localAori.deposit(order2, signature2, srcHook2);
 
         // Verify both orders were settled immediately
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Settled, "First order should be settled");
-        assertTrue(localAori.orderStatus(localAori.hash(order2)) == OrderStatus.Settled, "Second order should be settled");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Settled, "First order should be settled");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order2))) == OrderStatus.Settled, "Second order should be settled");
 
         // Verify no locked balances remain for either order
         assertEq(localLens.getLockedBalances(userSC, address(inputToken)), 0, "User should have no locked balance after both swaps");

--- a/test/foundry/SC_ERC20ToNativeSrcHook.t.sol
+++ b/test/foundry/SC_ERC20ToNativeSrcHook.t.sol
@@ -187,7 +187,7 @@ contract SC_ERC20ToNativeSrcHook_Test is TestUtils {
         );
 
         // Verify order status is Settled (atomic settlement for single-chain with srcHook)
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Settled, "Order should be Settled");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Settled, "Order should be Settled");
     }
 
     /**
@@ -278,7 +278,7 @@ contract SC_ERC20ToNativeSrcHook_Test is TestUtils {
         console.log("");
 
         // Verify final state
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Settled, "Order should be Settled");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Settled, "Order should be Settled");
 
         // Verify no locked balances remain (atomic settlement with direct distribution)
         assertEq(localLens.getLockedBalances(userSC, address(inputToken)), 0, "User should have no locked balance after atomic settlement");
@@ -308,7 +308,7 @@ contract SC_ERC20ToNativeSrcHook_Test is TestUtils {
         assertEq(localLens.getUnlockedBalances(solverSC, NATIVE_TOKEN), EXPECTED_SURPLUS);
 
         // Order should be immediately settled
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Settled, "Order should be Settled");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Settled, "Order should be Settled");
     }
 
     /**
@@ -349,7 +349,7 @@ contract SC_ERC20ToNativeSrcHook_Test is TestUtils {
         );
 
         bytes memory signature = signOrder(order, userSCPrivKey);
-        bytes32 expectedOrderId = localAori.hash(order);
+        bytes32 expectedOrderId = keccak256(abi.encode(order));
 
         SrcHook memory srcHook = SrcHook({
             hookAddress: address(mockHook2),
@@ -429,7 +429,7 @@ contract SC_ERC20ToNativeSrcHook_Test is TestUtils {
 
         // Verify order was settled atomically (not just filled)
         assertTrue(
-            localAori.orderStatus(localAori.hash(order)) == OrderStatus.Settled,
+            localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Settled,
             "Single-chain swap with srcHook should be immediately settled"
         );
 

--- a/test/foundry/SC_NativeHookAtomicSwap.t.sol
+++ b/test/foundry/SC_NativeHookAtomicSwap.t.sol
@@ -140,9 +140,10 @@ contract SC_NativeHookAtomicSwap_Test is TestUtils {
             dstEid: localEid, // same chain
             options: Options({
                 feeMbps: 0,
+                slippageMbps: 0,
                 feeRecipient: address(0),
-                solver: solverSC, // Solver gets surplus
-                slippageMbps: 0
+                srcSolver: solverSC, // Solver gets surplus
+                dstSolver: address(0)
             })
         });
     }
@@ -199,7 +200,7 @@ contract SC_NativeHookAtomicSwap_Test is TestUtils {
         );
 
         // Verify order status is Settled
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Settled, "Order should be Settled");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Settled, "Order should be Settled");
     }
 
     /**
@@ -263,7 +264,7 @@ contract SC_NativeHookAtomicSwap_Test is TestUtils {
     function testSingleChainNativeHookOrderStatus() public {
         _executeDepositNativeWithHook();
 
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
         assertTrue(localAori.orderStatus(orderId) == OrderStatus.Settled, "Single-chain swap should be immediately Settled");
     }
 
@@ -355,7 +356,7 @@ contract SC_NativeHookAtomicSwap_Test is TestUtils {
      */
     /**
      * @notice Test that surplus goes to specified solver in order.options
-     * @dev Solver validation is now done via order.options.solver, not srcHook.solver
+     * @dev Solver validation is now done via order.options.srcSolver, not srcHook.solver
      */
     function testSurplusGoesToSpecifiedSolver() public {
         vm.chainId(localEid);
@@ -376,9 +377,10 @@ contract SC_NativeHookAtomicSwap_Test is TestUtils {
             dstEid: localEid,
             options: Options({
                 feeMbps: 0,
+                slippageMbps: 0,
                 feeRecipient: address(0),
-                solver: specifiedSolver, // Surplus should go here
-                slippageMbps: 0
+                srcSolver: specifiedSolver, // Surplus should go here
+                dstSolver: address(0)
             })
         });
 
@@ -460,7 +462,7 @@ contract SC_NativeHookAtomicSwap_Test is TestUtils {
         assertEq(address(mockHook2).balance, initialHookNative + INPUT_AMOUNT, "Hook received 1 ETH");
         assertEq(outputToken.balanceOf(address(mockHook2)), initialHookTokens - HOOK_OUTPUT, "Hook sent 1100 tokens");
 
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Settled, "Order is Settled");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Settled, "Order is Settled");
 
         console.log("All assertions passed!");
     }

--- a/test/foundry/SC_NativeToERC20Hook.t.sol
+++ b/test/foundry/SC_NativeToERC20Hook.t.sol
@@ -223,7 +223,7 @@ contract SC_NativeToERC20Hook_Test is TestUtils {
         assertEq(address(localAori).balance, initialContractBalance + INPUT_AMOUNT, "Contract should receive native tokens");
 
         // Verify order status is Active (waiting for fill)
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Active, "Order should be Active");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Active, "Order should be Active");
     }
 
     /**
@@ -252,7 +252,7 @@ contract SC_NativeToERC20Hook_Test is TestUtils {
         );
 
         // Verify order status is Settled (atomic settlement for single-chain)
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Settled, "Order should be Settled");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Settled, "Order should be Settled");
     }
 
     /**
@@ -381,7 +381,7 @@ contract SC_NativeToERC20Hook_Test is TestUtils {
         // Verify final state
         assertEq(localLens.getLockedBalances(userSC, NATIVE_TOKEN), 0, "User should have no locked balance after atomic settlement");
         assertEq(localLens.getUnlockedBalances(solverSC, NATIVE_TOKEN), INPUT_AMOUNT, "Solver should have unlocked native balance");
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Settled, "Order should be Settled");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Settled, "Order should be Settled");
     }
 
     /**
@@ -462,7 +462,7 @@ contract SC_NativeToERC20Hook_Test is TestUtils {
         _fillOrderWithHook();
 
         // Verify order was settled atomically (not just filled)
-        assertTrue(localAori.orderStatus(localAori.hash(order)) == OrderStatus.Settled, "Single-chain swap should be immediately settled");
+        assertTrue(localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Settled, "Single-chain swap should be immediately settled");
 
         // Verify no locked balances remain (atomic settlement)
         assertEq(localLens.getLockedBalances(userSC, NATIVE_TOKEN), 0, "User should have no locked balance after atomic settlement");
@@ -479,7 +479,7 @@ contract SC_NativeToERC20Hook_Test is TestUtils {
         _createAndDepositNativeOrder();
         _fillOrderWithHook();
         assertTrue(
-            localAori.orderStatus(localAori.hash(order)) == OrderStatus.Settled, "First single-chain swap should be immediately settled"
+            localAori.orderStatus(keccak256(abi.encode(order))) == OrderStatus.Settled, "First single-chain swap should be immediately settled"
         );
 
         // Verify no locked balances remain for first order

--- a/test/foundry/SC_NativeToERC20NoHook.t.sol
+++ b/test/foundry/SC_NativeToERC20NoHook.t.sol
@@ -174,7 +174,7 @@ contract SC_NativeToERC20NoHook_Test is TestUtils {
         );
 
         bytes memory signature = signOrder(order, userSCPrivKey);
-        orderId = localAori.hash(order);
+        orderId = keccak256(abi.encode(order));
 
         // User deposits native tokens directly
         vm.prank(userSC);
@@ -307,7 +307,7 @@ contract SC_NativeToERC20NoHook_Test is TestUtils {
         );
 
         bytes memory signature = signOrder(order, userSCPrivKey);
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         // Phase 1: User deposits native tokens
         vm.prank(userSC);
@@ -355,7 +355,7 @@ contract SC_NativeToERC20NoHook_Test is TestUtils {
         );
 
         bytes memory signature = signOrder(order, userSCPrivKey);
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         // Initial: Unknown
         assertTrue(localAori.orderStatus(orderId) == OrderStatus.Unknown, "Order should start as Unknown");
@@ -396,7 +396,7 @@ contract SC_NativeToERC20NoHook_Test is TestUtils {
         );
 
         bytes memory signature = signOrder(order, userSCPrivKey);
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         // Phase 1: Deposit should emit Deposit event
         vm.expectEmit(true, false, false, true);
@@ -552,7 +552,7 @@ contract SC_NativeToERC20NoHook_Test is TestUtils {
         );
 
         bytes memory signature = signOrder(order, userSCPrivKey);
-        bytes32 orderId = localAori.hash(order);
+        bytes32 orderId = keccak256(abi.encode(order));
 
         // Deposit
         vm.prank(userSC);

--- a/test/foundry/TestUtils.sol
+++ b/test/foundry/TestUtils.sol
@@ -181,8 +181,8 @@ contract TestUtils is TestHelperOz5 {
             offerer: userA,
             recipient: userA,
             inputToken: address(inputToken),
-            outputToken: address(outputToken),
             inputAmount: uint128(inputAmount),
+            outputToken: address(outputToken),
             outputAmount: uint128(outputAmount),
             startTime: uint32(block.timestamp), // Set to current timestamp
             endTime: uint32(block.timestamp + endTimeOffset),
@@ -218,8 +218,8 @@ contract TestUtils is TestHelperOz5 {
             offerer: _offerer,
             recipient: _recipient,
             inputToken: _inputToken,
-            outputToken: _outputToken,
             inputAmount: uint128(_inputAmount),
+            outputToken: _outputToken,
             outputAmount: uint128(_outputAmount),
             startTime: uint32(_startTime),
             endTime: uint32(_endTime),
@@ -245,11 +245,12 @@ contract TestUtils is TestHelperOz5 {
         // Hash the nested Options struct first
         bytes32 optionsHash = keccak256(
             abi.encode(
-                keccak256("Options(uint16 feeMbps,address feeRecipient,address solver,uint16 slippageMbps)"),
+                keccak256("Options(uint16 feeMbps,uint16 slippageMbps,address feeRecipient,address srcSolver,address dstSolver)"),
                 order.options.feeMbps,
+                order.options.slippageMbps,
                 order.options.feeRecipient,
-                order.options.solver,
-                order.options.slippageMbps
+                order.options.srcSolver,
+                order.options.dstSolver
             )
         );
 
@@ -257,17 +258,17 @@ contract TestUtils is TestHelperOz5 {
         bytes32 structHash = keccak256(
             abi.encode(
                 keccak256(
-                    "Order(uint128 inputAmount,uint128 outputAmount,address inputToken,address outputToken,"
-                    "uint32 startTime,uint32 endTime,uint32 srcEid,uint32 dstEid,address offerer,address recipient," "Options options)"
-                    "Options(uint16 feeMbps,address feeRecipient,address solver,uint16 slippageMbps)"
+                    "Order(uint128 inputAmount,uint128 outputAmount,address inputToken,uint32 startTime,"
+                    "uint32 endTime,uint32 srcEid,address outputToken,uint32 dstEid,address offerer,address recipient," "Options options)"
+                    "Options(uint16 feeMbps,uint16 slippageMbps,address feeRecipient,address srcSolver,address dstSolver)"
                 ),
                 order.inputAmount,
                 order.outputAmount,
                 order.inputToken,
-                order.outputToken,
                 order.startTime,
                 order.endTime,
                 order.srcEid,
+                order.outputToken,
                 order.dstEid,
                 order.offerer,
                 order.recipient,
@@ -296,9 +297,10 @@ contract TestUtils is TestHelperOz5 {
     function defaultOrderOptions() public pure returns (Options memory) {
         return Options({
             feeMbps: 0,
+            slippageMbps: 0, // 0 = limit order
             feeRecipient: address(0),
-            solver: address(0), // Any whitelisted solver allowed
-            slippageMbps: 0 // 0 = limit order
+            srcSolver: address(0), // Any whitelisted solver allowed
+            dstSolver: address(0) // Any whitelisted solver allowed
          });
     }
 
@@ -310,7 +312,7 @@ contract TestUtils is TestHelperOz5 {
     function marketOrderOptions(
         uint16 slippageMbps
     ) public pure returns (Options memory) {
-        return Options({ feeMbps: 0, feeRecipient: address(0), solver: address(0), slippageMbps: slippageMbps });
+        return Options({ feeMbps: 0, slippageMbps: slippageMbps, feeRecipient: address(0), srcSolver: address(0), dstSolver: address(0) });
     }
 
     /**
@@ -320,7 +322,7 @@ contract TestUtils is TestHelperOz5 {
      * @return Options struct with fee configuration
      */
     function feeOrderOptions(uint16 feeMbps, address feeRecipient) public pure returns (Options memory) {
-        return Options({ feeMbps: feeMbps, feeRecipient: feeRecipient, solver: address(0), slippageMbps: 0 });
+        return Options({ feeMbps: feeMbps, slippageMbps: 0, feeRecipient: feeRecipient, srcSolver: address(0), dstSolver: address(0) });
     }
 
     /**


### PR DESCRIPTION
  - Split `Options.solver` into `srcSolver` (validated on source chain) and `dstSolver` (validated on destination chain)                                                          
  - Reordered `Order` and `Options` struct fields for optimal storage packing                                                                                                   
  - Updated EIP-712 typehashes and hashing to reflect new struct layout                                                                                                     
  - Updated `ValidationUtils` to validate `srcSolver` on deposit, `dstSolver `on fill
  - Rewrote `AoriLens.orders()` for new 8-slot storage layout                                                                                                                 
  - Moved `hash()` from Aori.sol to AoriLens.sol to stay under bytecode size limit
  - Updated all test files for new struct field order, `Options` construction, and `hash` usage