### PR TITLE
Feat/remove dead settlement payload fns

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,35 @@ struct Order {
     uint32 dstEid;            // Destination chain endpoint ID
     address offerer;          // User who created the order
     address recipient;        // Address to receive output tokens
-    Options options;
+    Options options;          // User-signed order configuration
 }
 ```
 
+### Options
+
+The `Options` struct is nested inside `Order` and signed by the user, giving them explicit control over fee configuration, solver binding, and order type:
+
+```solidity
+struct Options {
+    uint16 feeMbps;        // Fee in millibasis points (1000 = 1%)
+    address feeRecipient;  // Who receives the fee (address(0) = solver)
+    address solver;        // Authorized solver (address(0) = any whitelisted)
+    uint16 slippageMbps;   // 0 = limit order, >0 = market order
+}
+```
+
+- **`solver`** — If set, only this solver can deposit/fill the order. If `address(0)`, any whitelisted solver can.
+- **`feeMbps`** — An additional fee the user agrees to pay, capped by the protocol's `maxFeeMbps`.
+- **`feeRecipient`** — Where the additional fee goes. `address(0)` routes it to the solver.
+- **`slippageMbps`** — Determines the order type and surplus routing (see [Order Types](#order-types--slippage) below).
+
 ### Native Token Support
 
-The protocol supports both ERC-20 tokens and native tokens (ETH/native chain currency). Native tokens are represented by the address `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE` and can be deposited using the `depositNative()` function. The `TokenUtils` library abstracts the handling of transfers and balance observations for both token types.
+The protocol supports both ERC-20 tokens and native tokens (ETH/native chain currency). Native tokens are represented by the address `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE` and can be deposited using `depositNative()`. The `TokenUtils` library abstracts the handling of transfers and balance observations for both token types.
+
+### Permit2 Support
+
+Users can deposit via [Permit2](https://github.com/Uniswap/permit2) witness-based signatures using `depositWithPermit2()`. The `Order` struct serves as the Permit2 witness, binding the token transfer authorization to the specific order in a single signature — eliminating the need for a separate ERC-20 `approve` transaction.
 
 ### Order Lifecycle
 
@@ -77,14 +99,14 @@ sequenceDiagram
 
 #### Deposit & Fill Process
 
-1. User signs an order with EIP-712 signature
-2. Solver submits the order and signature to source chain using `deposit()` for ERC-20 tokens
-3. For native tokens, users call `depositNative()` directly with ETH sent via `msg.value`
+1. User signs an order with EIP-712 signature (includes `Options` for fee/solver/slippage configuration)
+2. Solver submits the order and signature to source chain using `deposit()` for ERC-20 tokens, `depositNative()` for native tokens, or `depositWithPermit2()` for gasless approval
+3. If `order.options.solver` is set, only that solver can submit the deposit/fill
 4. Tokens are locked in the source chain contract
 5. Solver fulfills the order on the destination chain
 6. Tokens are transferred to the recipient on destination chain
 7. Settlement message is sent back to source chain (with MessagingReceipt data captured in events)
-8. Source chain transfers locked tokens to solver
+8. Source chain deducts fees (protocol + additional) and transfers remaining locked tokens to solver
 
 #### Cancellation Process
 
@@ -120,46 +142,24 @@ sequenceDiagram
 #### Settlement Process
 
 1. Fill Recording: When orders are filled on destination chain, they're stored in the solver's fill array.
-2. Batch Settlement: Solvers can batch up to MAX_FILLS_PER_SETTLE orders for efficient processing.
+2. Batch Settlement: Solvers can batch up to `maxFillsPerSettle` orders for efficient processing.
 3. Cross-Chain Message: A settlement payload containing filler address and order hashes is sent via LayerZero.
 4. Receipt Tracking: MessagingReceipt information (guid, nonce, fee) is captured and included in the SettleSent event.
 5. Source Chain Processing: The source chain:
    - Validates orders are in Active state
-   - Transfers tokens from locked to unlocked state for the solver
+   - Calculates protocol fee and additional fee from the locked amount
+   - Credits solver with `inputAmount - protocolFee - additionalFee`
+   - Accrues protocol fee to `pendingProtocolFees` (lazy accrual)
+   - Credits additional fee to `feeRecipient` balance
    - Marks orders as Settled
-   - Skips problematic orders without reverting the entire batch
-6. Events: Emits Settle events for successful settlements.
+   - Skips problematic orders via soft-fail rollback without reverting the entire batch
+6. Events: Emits `Settle` events with fee breakdown for successful settlements, `SettleFailed` for skipped orders.
 
 This design ensures efficient, secure settlement while gracefully handling partial failures.
 
 ## Single-Chain Swap Architecture
 
 Single-chain swap orders are also supported by Aori.sol. These orders bypass the complex cross-chain messaging and offer efficient peer to peer settlement. The contract supports three main fulfillment paths for single-chain swaps:
-
-#### Immediate Fulfillment via `swap`
-
-```mermaid
-sequenceDiagram
-    actor User
-    actor Solver
-    participant Aori as Aori Contract
-
-    User->>Solver: Signed Order
-    Solver->>Aori: swap(order, signature)
-    User-->>Aori: Input tokens locked
-    Solver-->>Aori: Output tokens provided
-    Aori-->>User: Output tokens transferred to recipient
-    Aori-->>Solver: Input tokens credited (unlocked)
-```
-
-In this atomic flow:
-1. Solver calls `swap()` with the user's signed order
-2. Input tokens are transferred from the user to the contract
-3. Output tokens are transferred from the solver to the recipient
-4. Input tokens are immediately credited to the solver (unlocked balance)
-5. Order is marked as Settled in a single transaction
-
-This is the most gas-efficient path but requires the solver to already have the output tokens.
 
 #### Delayed Fulfillment via deposit then fill
 
@@ -191,9 +191,9 @@ In this two-step flow:
 
 This pattern gives solvers flexibility to lock in the user's intent first, then source the output tokens before completing the trade. The settlement happens immediately after the fill call without needing cross-chain messaging.
 
-#### Deposit with Hook Path
+#### Atomic Swap via Deposit with Hook
 
-The contract also supports a hook-based deposit mechanism for single-chain swaps:
+The contract supports a hook-based deposit mechanism for single-chain swaps that settles atomically with fee distribution:
 
 ```mermaid
 sequenceDiagram
@@ -204,22 +204,69 @@ sequenceDiagram
 
     User->>Solver: Signed Order
     Solver->>Aori: deposit(order, signature, hook)
-    User-->>Aori: Input tokens transferred
-    Aori->>Hook: Input tokens + execute hook
+    User-->>Aori: Input tokens transferred to hook
+    Aori->>Hook: Execute hook (token conversion)
     Hook-->>Aori: Output tokens returned
-    Aori-->>User: Output tokens to recipient
-    Aori-->>Solver: Input tokens credited
+    Aori-->>User: Output tokens to recipient (minus fees)
+    Note over Aori: Protocol fee → pendingProtocolFees
+    Note over Aori: Additional fee → feeRecipient balance
+    Aori-->>Solver: Surplus credited (limit orders only)
 ```
 
 In this path:
 1. Solver calls `deposit()` with the user's order, signature, and hook configuration
 2. Input tokens are transferred directly to the hook contract
-3. The hook executes a route
+3. The hook executes a route (e.g. DEX swap)
 4. Output tokens are returned to the Aori contract
-5. Output tokens are transferred to the recipient
-6. Settlement happens immediately, crediting the input amount to the solver
+5. Output is validated against `minOutput` (slippage protection)
+6. Fees are deducted and distributed (protocol fee + additional fee)
+7. Recipient receives output minus fees
+8. For limit orders (`slippageMbps = 0`), surplus goes to solver
+9. Order is marked as Settled in a single transaction
 
 This pattern enables advanced liquidity sourcing directly within the transaction.
+
+## Order Types & Slippage
+
+The `slippageMbps` field in `Options` determines order type and who captures price improvement (surplus):
+
+| `slippageMbps` | Order Type | Surplus Goes To | Minimum Output |
+|---|---|---|---|
+| `0` | Limit | Solver | `outputAmount` (exact) |
+| `> 0` | Market | Recipient | `outputAmount × (1 - slippage%)` |
+
+**Limit orders** (`slippageMbps = 0`) — The solver must deliver at least `outputAmount`. Any surplus from execution efficiency is captured by the solver as profit.
+
+**Market orders** (`slippageMbps > 0`) — The recipient captures all price improvement. The solver is compensated via fees instead. The minimum acceptable output is:
+
+```
+minOutput = outputAmount × (100000 - slippageMbps) / 100000
+```
+
+Solvers cannot tamper with `slippageMbps` because the `orderId` is derived from `keccak256(abi.encode(order))` — modifying any field changes the hash, and settlement will fail since the source chain won't find the original order.
+
+## Fee System
+
+Aori uses a dual-fee system with **protocol fees** (governance-controlled) and **additional fees** (user-signed):
+
+| Fee | Set By | Recipient | Limit |
+|---|---|---|---|
+| **Protocol Fee** | Governance (`setProtocolFee`) | `protocolTreasury` | Cross-validated with `maxFeeMbps` |
+| **Additional Fee** | User (signed `order.options.feeMbps`) | `feeRecipient` (or solver if `address(0)`) | Capped by `maxFeeMbps` |
+
+Both fees are deducted from the basis amount. The fee token depends on the execution path:
+
+| Path | Fee Token | Collection Point |
+|---|---|---|
+| Atomic swap (deposit with hook, single-chain) | `outputToken` | At swap execution |
+| Deposit → fill → settle | `inputToken` | At settlement |
+
+**Key design decisions:**
+- Fees and surplus accrue to internal `unlocked` balances rather than immediate transfers (~21,000 gas saved per avoided transfer)
+- Protocol fees use lazy accrual (`pendingProtocolFees[token]`) — `claimProtocolFees()` is permissionless (funds always go to treasury)
+- `setProtocolFee` and `setMaxFee` cross-validate: combined fees can never exceed 100%
+- Settlement uses soft-fail with rollback to prevent one bad order from blocking a batch
+
 
 ---
 

--- a/contracts/utils/PayloadUtils.sol
+++ b/contracts/utils/PayloadUtils.sol
@@ -142,8 +142,6 @@ library PayloadUtils {
 
     /**
      * @notice Validates and unpacks a settlement payload in a single operation
-     * @dev Consolidates validateSettlementLen() + unpackSettlementHeader() + validateSettlementLen(fillCount)
-     *      More gas efficient at runtime by avoiding multiple function calls
      * @param payload The settlement payload to validate and unpack
      * @return filler The filler address
      * @return fillCount The number of fills in the payload

--- a/contracts/utils/PayloadUtils.sol
+++ b/contracts/utils/PayloadUtils.sol
@@ -141,45 +141,6 @@ library PayloadUtils {
     }
 
     /**
-     * @notice Validates the minimum length of a settlement payload
-     * @dev Ensures the payload is at least 23 bytes (header size)
-     * @param payload The payload to validate
-     */
-    /* forgefmt: disable-next-item */
-    function validateSettlementLen(bytes calldata payload) internal pure {
-        if (payload.length < 23) revert InvalidPayloadLength(23, payload.length);
-    }
-
-    /**
-     * @notice Validates the length of a settlement payload for a specific fill count
-     * @dev Ensures the payload matches the expected size based on fill count
-     * @param payload The payload to validate
-     * @param fillCount The number of fills in the payload
-     */
-    function validateSettlementLen(bytes calldata payload, uint16 fillCount) internal pure {
-        uint256 expectedLen = 23 + uint256(fillCount) * 32;
-        if (payload.length != expectedLen) revert InvalidPayloadLength(expectedLen, payload.length);
-    }
-
-    /**
-     * @notice Unpacks the header from a settlement payload
-     * @dev Extracts the filler address (20 bytes) and fill count (2 bytes)
-     * @param payload The settlement payload to unpack
-     * @return filler The filler address
-     * @return fillCount The number of fills in the payload
-     */
-    function unpackSettlementHeader(
-        bytes calldata payload
-    ) internal pure returns (address filler, uint16 fillCount) {
-        if (payload.length < 23) revert InvalidPayloadLength(23, payload.length);
-        assembly {
-            let word := calldataload(add(payload.offset, 1))
-            filler := shr(96, word)
-        }
-        fillCount = (uint16(uint8(payload[21])) << 8) | uint16(uint8(payload[22]));
-    }
-
-    /**
      * @notice Validates and unpacks a settlement payload in a single operation
      * @dev Consolidates validateSettlementLen() + unpackSettlementHeader() + validateSettlementLen(fillCount)
      *      More gas efficient at runtime by avoiding multiple function calls

--- a/test/foundry/24_PayloadTesting.t.sol
+++ b/test/foundry/24_PayloadTesting.t.sol
@@ -10,22 +10,16 @@ pragma solidity 0.8.34;
  * 3. test_getType_invalid - Tests payload type detection with invalid types
  * 4. test_validateCancellationLen_valid - Tests validation of correct cancellation payload length
  * 5. test_validateCancellationLen_invalid - Tests validation fails with incorrect cancellation payload length
- * 6. test_validateSettlementLen_validMin - Tests validation of minimum valid settlement payload length
- * 7. test_validateSettlementLen_invalidTooShort - Tests validation fails with too short settlement payload
- * 8. test_validateSettlementLen_withFillCount_valid - Tests validation with specific fill count
- * 9. test_validateSettlementLen_withFillCount_invalid - Tests validation fails with incorrect fill count length
- * 10. test_unpackCancellation_valid - Tests unpacking a valid cancellation payload
- * 11. test_unpackSettlementHeader_valid - Tests unpacking a valid settlement header
- * 12. test_unpackSettlementHeader_invalidLength - Tests unpacking fails with invalid header length
- * 13. test_unpackSettlementBodyAt_validIndex - Tests unpacking valid order hash at specific index
- * 14. test_unpackSettlementBodyAt_invalidIndex - Tests unpacking fails with invalid index
- * 15. test_packCancellation - Tests packing a cancellation payload
- * 16. test_packSettlement_singleOrder - Tests packing a settlement payload with a single order
- * 17. test_packSettlement_multipleOrders - Tests packing a settlement payload with multiple orders
- * 18. test_packSettlement_maxOrders - Tests packing with maximum number of orders
- * 19. test_settlementPayloadSize - Tests the calculation of settlement payload size
- * 20. test_integration_packAndUnpack_cancellation - Tests full round-trip packing and unpacking of cancellation
- * 21. test_integration_packAndUnpack_settlement - Tests full round-trip packing and unpacking of settlement
+ * 6. test_unpackCancellation_valid - Tests unpacking a valid cancellation payload
+ * 7. test_unpackSettlementBodyAt_validIndex - Tests unpacking valid order hash at specific index
+ * 8. test_unpackSettlementBodyAt_invalidIndex - Tests unpacking fails with invalid index
+ * 9. test_packCancellation - Tests packing a cancellation payload
+ * 10. test_packSettlement_singleOrder - Tests packing a settlement payload with a single order
+ * 11. test_packSettlement_multipleOrders - Tests packing a settlement payload with multiple orders
+ * 12. test_packSettlement_maxOrders - Tests packing with maximum number of orders
+ * 13. test_settlementPayloadSize - Tests the calculation of settlement payload size
+ * 14. test_integration_packAndUnpack_cancellation - Tests full round-trip packing and unpacking of cancellation
+ * 15. test_integration_packAndUnpack_settlement - Tests full round-trip packing and unpacking of settlement
  *
  * This test file verifies all payload packing and unpacking functions, with special focus on
  * assembly-level implementations and proper validation of payload formats. Edge cases like
@@ -58,16 +52,6 @@ contract PayloadTestWrapper {
         PayloadUtils.validateCancellationLen(payload);
     }
 
-    function validateSettlementLen(
-        bytes calldata payload
-    ) external pure {
-        PayloadUtils.validateSettlementLen(payload);
-    }
-
-    function validateSettlementLen(bytes calldata payload, uint16 fillCount) external pure {
-        PayloadUtils.validateSettlementLen(payload, fillCount);
-    }
-
     // Unpacking functions
     function getType(
         bytes calldata payload
@@ -79,12 +63,6 @@ contract PayloadTestWrapper {
         bytes calldata payload
     ) external pure returns (bytes32) {
         return PayloadUtils.unpackCancellation(payload);
-    }
-
-    function unpackSettlementHeader(
-        bytes calldata payload
-    ) external pure returns (address filler, uint16 fillCount) {
-        return PayloadUtils.unpackSettlementHeader(payload);
     }
 
     function unpackSettlementBodyAt(bytes calldata payload, uint256 index) external pure returns (bytes32) {
@@ -252,70 +230,6 @@ contract PayloadPackingUnpackingTest is Test {
         wrapper.validateCancellationLen(payload);
     }
 
-    /// @dev Tests validation of minimum valid settlement payload length
-    /// @notice Covers lines 268-269 in AoriUtils.sol
-    function test_validateSettlementLen_validMin() public view {
-        // Arrange - minimal valid settlement payload (23 bytes)
-        bytes memory payload = abi.encodePacked(
-            uint8(PayloadType.Settlement),
-            bytes20(TEST_FILLER), // filler address
-            uint16(0) // 0 fills
-        );
-
-        // Act & Assert - should not revert
-        wrapper.validateSettlementLen(payload);
-    }
-
-    /// @dev Tests validation fails with too short settlement payload
-    /// @notice Covers lines 268-269 in AoriUtils.sol
-    function test_validateSettlementLen_invalidTooShort() public {
-        // Arrange - too short (22 bytes - missing 1 byte from fill count)
-        bytes memory payload = abi.encodePacked(
-            uint8(PayloadType.Settlement),
-            bytes20(TEST_FILLER), // filler address
-            bytes1(0) // only 1 byte of fill count
-        );
-
-        // Act & Assert - payload is 22 bytes, expected 23
-        vm.expectRevert(abi.encodeWithSelector(InvalidPayloadLength.selector, 23, 22));
-        wrapper.validateSettlementLen(payload);
-    }
-
-    /// @dev Tests validation with specific fill count
-    /// @notice Covers lines 278-284 in AoriUtils.sol
-    function test_validateSettlementLen_withFillCount_valid() public view {
-        // Arrange - 2 fills (header + 2 order hashes = 23 + 64 = 87 bytes)
-        uint16 fillCount = 2;
-        bytes memory payload = abi.encodePacked(
-            uint8(PayloadType.Settlement),
-            bytes20(TEST_FILLER), // filler address
-            fillCount, // fill count
-            TEST_ORDER_HASH, // order hash 1
-            TEST_ORDER_HASH // order hash 2
-        );
-
-        // Act & Assert - should not revert
-        wrapper.validateSettlementLen(payload, fillCount);
-    }
-
-    /// @dev Tests validation fails with incorrect fill count length
-    /// @notice Covers lines 278-284 in AoriUtils.sol
-    function test_validateSettlementLen_withFillCount_invalid() public {
-        // Arrange - payload for 2 fills but specify 3 fills
-        uint16 fillCount = 3;
-        bytes memory payload = abi.encodePacked(
-            uint8(PayloadType.Settlement),
-            bytes20(TEST_FILLER), // filler address
-            uint16(2), // actual fill count in payload
-            TEST_ORDER_HASH, // order hash 1
-            TEST_ORDER_HASH // order hash 2
-        );
-
-        // Act & Assert - expected = 23 + 3*32 = 119, actual = 23 + 2*32 = 87
-        vm.expectRevert(abi.encodeWithSelector(InvalidPayloadLength.selector, 119, 87));
-        wrapper.validateSettlementLen(payload, fillCount);
-    }
-
     /**
      *
      */
@@ -335,39 +249,6 @@ contract PayloadPackingUnpackingTest is Test {
 
         // Assert
         assertEq(orderHash, TEST_ORDER_HASH);
-    }
-
-    /// @dev Tests unpacking a valid settlement header
-    /// @notice Covers lines 302-310 in AoriUtils.sol
-    function test_unpackSettlementHeader_valid() public view {
-        // Arrange
-        uint16 fillCount = 5;
-        bytes memory payload = abi.encodePacked(
-            uint8(PayloadType.Settlement),
-            bytes20(TEST_FILLER), // filler address
-            fillCount // fill count
-        );
-
-        // Act
-        (address filler, uint16 unpacked_fillCount) = wrapper.unpackSettlementHeader(payload);
-
-        // Assert
-        assertEq(filler, TEST_FILLER);
-        assertEq(unpacked_fillCount, fillCount);
-    }
-
-    /// @dev Tests unpacking fails with invalid header length
-    /// @notice Covers lines 302-310 in AoriUtils.sol
-    function test_unpackSettlementHeader_invalidLength() public {
-        // Arrange - too short
-        bytes memory payload = abi.encodePacked(
-            uint8(PayloadType.Settlement),
-            bytes19(0) // Only 19 bytes instead of 20 for address
-        );
-
-        // Act & Assert - payload is 20 bytes, expected >= 23
-        vm.expectRevert(abi.encodeWithSelector(InvalidPayloadLength.selector, 23, 20));
-        wrapper.unpackSettlementHeader(payload);
     }
 
     /// @dev Tests unpacking valid order hash at specific index
@@ -490,8 +371,14 @@ contract PayloadPackingUnpackingTest is Test {
         console.log("  Expected:", SETTLEMENT_TYPE);
         console.log("  Actual:", uint8(payload[0]));
 
-        // Extract filler address using unpackSettlementHeader function
-        (address unpackedFiller, uint16 unpackedFillCount) = wrapper.unpackSettlementHeader(payload);
+        // Extract filler address from payload manually
+        address unpackedFiller;
+        uint16 unpackedFillCount;
+        assembly {
+            let word := mload(add(payload, 33))
+            unpackedFiller := shr(96, word)
+        }
+        unpackedFillCount = (uint16(uint8(payload[21])) << 8) | uint16(uint8(payload[22]));
         console.log("UNPACKED HEADER:");
         console.log("  Filler Address:");
         console.logAddress(unpackedFiller);
@@ -568,8 +455,14 @@ contract PayloadPackingUnpackingTest is Test {
         console.log("  Expected Length:", 23 + takeSize * 32);
         console.log("  Actual Length:", payload.length);
 
-        // Extract header using unpackSettlementHeader
-        (address unpackedFiller, uint16 unpackedFillCount) = wrapper.unpackSettlementHeader(payload);
+        // Extract header manually
+        address unpackedFiller;
+        uint16 unpackedFillCount;
+        assembly {
+            let word := mload(add(payload, 33))
+            unpackedFiller := shr(96, word)
+        }
+        unpackedFillCount = (uint16(uint8(payload[21])) << 8) | uint16(uint8(payload[22]));
         console.log("UNPACKED HEADER:");
         console.log("  Filler Address:");
         console.logAddress(unpackedFiller);
@@ -747,8 +640,13 @@ contract PayloadPackingUnpackingTest is Test {
 
         // Act - Unpack
         PayloadType payloadType = wrapper.getType(payload);
-        wrapper.validateSettlementLen(payload);
-        (address unpackedFiller, uint16 unpackedFillCount) = wrapper.unpackSettlementHeader(payload);
+        address unpackedFiller;
+        uint16 unpackedFillCount;
+        assembly {
+            let word := mload(add(payload, 33))
+            unpackedFiller := shr(96, word)
+        }
+        unpackedFillCount = (uint16(uint8(payload[21])) << 8) | uint16(uint8(payload[22]));
 
         // Log the unpacked header details
         console.log("UNPACKED HEADER:");

--- a/test/foundry/24_PayloadTesting.t.sol
+++ b/test/foundry/24_PayloadTesting.t.sol
@@ -10,16 +10,22 @@ pragma solidity 0.8.34;
  * 3. test_getType_invalid - Tests payload type detection with invalid types
  * 4. test_validateCancellationLen_valid - Tests validation of correct cancellation payload length
  * 5. test_validateCancellationLen_invalid - Tests validation fails with incorrect cancellation payload length
- * 6. test_unpackCancellation_valid - Tests unpacking a valid cancellation payload
- * 7. test_unpackSettlementBodyAt_validIndex - Tests unpacking valid order hash at specific index
- * 8. test_unpackSettlementBodyAt_invalidIndex - Tests unpacking fails with invalid index
- * 9. test_packCancellation - Tests packing a cancellation payload
- * 10. test_packSettlement_singleOrder - Tests packing a settlement payload with a single order
- * 11. test_packSettlement_multipleOrders - Tests packing a settlement payload with multiple orders
- * 12. test_packSettlement_maxOrders - Tests packing with maximum number of orders
- * 13. test_settlementPayloadSize - Tests the calculation of settlement payload size
- * 14. test_integration_packAndUnpack_cancellation - Tests full round-trip packing and unpacking of cancellation
- * 15. test_integration_packAndUnpack_settlement - Tests full round-trip packing and unpacking of settlement
+ * 6. test_validateAndUnpackSettlement_validMin - Tests validation and unpacking of minimum valid settlement payload
+ * 7. test_validateAndUnpackSettlement_invalidTooShort - Tests validation fails with too short settlement payload
+ * 8. test_validateAndUnpackSettlement_withFillCount_valid - Tests validation and unpacking with specific fill count
+ * 9. test_validateAndUnpackSettlement_withFillCount_invalid - Tests validation fails with incorrect fill count length
+ * 10. test_unpackCancellation_valid - Tests unpacking a valid cancellation payload
+ * 11. test_validateAndUnpackSettlement_validHeader - Tests validation and unpacking of a valid settlement header
+ * 12. test_validateAndUnpackSettlement_invalidHeaderLength - Tests validation fails with invalid header length
+ * 13. test_unpackSettlementBodyAt_validIndex - Tests unpacking valid order hash at specific index
+ * 14. test_unpackSettlementBodyAt_invalidIndex - Tests unpacking fails with invalid index
+ * 15. test_packCancellation - Tests packing a cancellation payload
+ * 16. test_packSettlement_singleOrder - Tests packing a settlement payload with a single order
+ * 17. test_packSettlement_multipleOrders - Tests packing a settlement payload with multiple orders
+ * 18. test_packSettlement_maxOrders - Tests packing with maximum number of orders
+ * 19. test_settlementPayloadSize - Tests the calculation of settlement payload size
+ * 20. test_integration_packAndUnpack_cancellation - Tests full round-trip packing and unpacking of cancellation
+ * 21. test_integration_packAndUnpack_settlement - Tests full round-trip packing and unpacking of settlement
  *
  * This test file verifies all payload packing and unpacking functions, with special focus on
  * assembly-level implementations and proper validation of payload formats. Edge cases like
@@ -63,6 +69,12 @@ contract PayloadTestWrapper {
         bytes calldata payload
     ) external pure returns (bytes32) {
         return PayloadUtils.unpackCancellation(payload);
+    }
+
+    function validateAndUnpackSettlement(
+        bytes calldata payload
+    ) external pure returns (address filler, uint16 fillCount) {
+        return PayloadUtils.validateAndUnpackSettlement(payload);
     }
 
     function unpackSettlementBodyAt(bytes calldata payload, uint256 index) external pure returns (bytes32) {
@@ -230,6 +242,72 @@ contract PayloadPackingUnpackingTest is Test {
         wrapper.validateCancellationLen(payload);
     }
 
+    /// @dev Tests validateAndUnpackSettlement with minimum valid settlement payload (0 fills)
+    function test_validateAndUnpackSettlement_validMin() public view {
+        // Arrange - minimal valid settlement payload (23 bytes, 0 fills)
+        bytes memory payload = abi.encodePacked(
+            uint8(PayloadType.Settlement),
+            bytes20(TEST_FILLER), // filler address
+            uint16(0) // 0 fills
+        );
+
+        // Act
+        (address filler, uint16 fillCount) = wrapper.validateAndUnpackSettlement(payload);
+
+        // Assert
+        assertEq(filler, TEST_FILLER);
+        assertEq(fillCount, 0);
+    }
+
+    /// @dev Tests validateAndUnpackSettlement fails with too short payload
+    function test_validateAndUnpackSettlement_invalidTooShort() public {
+        // Arrange - too short (22 bytes - missing 1 byte from fill count)
+        bytes memory payload = abi.encodePacked(
+            uint8(PayloadType.Settlement),
+            bytes20(TEST_FILLER), // filler address
+            bytes1(0) // only 1 byte of fill count
+        );
+
+        // Act & Assert - payload is 22 bytes, expected 23
+        vm.expectRevert(abi.encodeWithSelector(InvalidPayloadLength.selector, 23, 22));
+        wrapper.validateAndUnpackSettlement(payload);
+    }
+
+    /// @dev Tests validateAndUnpackSettlement with valid fill count
+    function test_validateAndUnpackSettlement_withFillCount_valid() public view {
+        // Arrange - 2 fills (header + 2 order hashes = 23 + 64 = 87 bytes)
+        uint16 fillCount = 2;
+        bytes memory payload = abi.encodePacked(
+            uint8(PayloadType.Settlement),
+            bytes20(TEST_FILLER), // filler address
+            fillCount, // fill count
+            TEST_ORDER_HASH, // order hash 1
+            TEST_ORDER_HASH // order hash 2
+        );
+
+        // Act
+        (address filler, uint16 unpackedFillCount) = wrapper.validateAndUnpackSettlement(payload);
+
+        // Assert
+        assertEq(filler, TEST_FILLER);
+        assertEq(unpackedFillCount, fillCount);
+    }
+
+    /// @dev Tests validateAndUnpackSettlement fails when payload length doesn't match fill count
+    function test_validateAndUnpackSettlement_withFillCount_invalid() public {
+        // Arrange - header says 2 fills but only 1 order hash in body
+        bytes memory payload = abi.encodePacked(
+            uint8(PayloadType.Settlement),
+            bytes20(TEST_FILLER), // filler address
+            uint16(2), // fill count says 2
+            TEST_ORDER_HASH // but only 1 order hash
+        );
+
+        // Act & Assert - expected = 23 + 2*32 = 87, actual = 23 + 1*32 = 55
+        vm.expectRevert(abi.encodeWithSelector(InvalidPayloadLength.selector, 87, 55));
+        wrapper.validateAndUnpackSettlement(payload);
+    }
+
     /**
      *
      */
@@ -249,6 +327,42 @@ contract PayloadPackingUnpackingTest is Test {
 
         // Assert
         assertEq(orderHash, TEST_ORDER_HASH);
+    }
+
+    /// @dev Tests validateAndUnpackSettlement with valid header
+    function test_validateAndUnpackSettlement_validHeader() public view {
+        // Arrange - 5 fills with proper body
+        uint16 fillCount = 5;
+        bytes32[] memory hashes = new bytes32[](5);
+        for (uint16 i = 0; i < 5; i++) {
+            hashes[i] = bytes32(uint256(TEST_ORDER_HASH) + i);
+        }
+        bytes memory payload = abi.encodePacked(
+            uint8(PayloadType.Settlement),
+            bytes20(TEST_FILLER),
+            fillCount,
+            hashes[0], hashes[1], hashes[2], hashes[3], hashes[4]
+        );
+
+        // Act
+        (address filler, uint16 unpacked_fillCount) = wrapper.validateAndUnpackSettlement(payload);
+
+        // Assert
+        assertEq(filler, TEST_FILLER);
+        assertEq(unpacked_fillCount, fillCount);
+    }
+
+    /// @dev Tests validateAndUnpackSettlement fails with invalid header length
+    function test_validateAndUnpackSettlement_invalidHeaderLength() public {
+        // Arrange - too short
+        bytes memory payload = abi.encodePacked(
+            uint8(PayloadType.Settlement),
+            bytes19(0) // Only 19 bytes instead of 20 for address
+        );
+
+        // Act & Assert - payload is 20 bytes, expected >= 23
+        vm.expectRevert(abi.encodeWithSelector(InvalidPayloadLength.selector, 23, 20));
+        wrapper.validateAndUnpackSettlement(payload);
     }
 
     /// @dev Tests unpacking valid order hash at specific index
@@ -342,92 +456,27 @@ contract PayloadPackingUnpackingTest is Test {
     }
 
     /// @dev Tests packing a settlement payload with a single order
-    /// @notice Covers lines 357-393 in AoriUtils.sol
     function test_packSettlement_singleOrder() public {
         // Arrange
         bytes32[] memory orderHashes = new bytes32[](1);
         orderHashes[0] = TEST_ORDER_HASH;
         wrapper.setupFillsArray(orderHashes);
 
-        // Log the input data
-        console.log("TEST SETUP:");
-        console.logBytes32(TEST_ORDER_HASH);
-        console.log("  Filler Address:");
-        console.logAddress(TEST_FILLER);
-        console.log("  Take Size:");
-        console.logUint(1);
-
         // Act
         bytes memory payload = wrapper.packSettlement(TEST_FILLER, 1);
 
-        // Calculate expected payload size
-        uint256 expectedSize = 23 + 32; // Header (23 bytes) + 1 order hash (32 bytes)
-        console.log("PAYLOAD SIZE:");
-        console.log("  Expected:", expectedSize);
-        console.log("  Actual:", payload.length);
+        // Validate and unpack using validateAndUnpackSettlement
+        (address unpackedFiller, uint16 unpackedFillCount) = wrapper.validateAndUnpackSettlement(payload);
 
-        // Log the payload type byte
-        console.log("PAYLOAD TYPE BYTE:");
-        console.log("  Expected:", SETTLEMENT_TYPE);
-        console.log("  Actual:", uint8(payload[0]));
-
-        // Extract filler address from payload manually
-        address unpackedFiller;
-        uint16 unpackedFillCount;
-        assembly {
-            let word := mload(add(payload, 33))
-            unpackedFiller := shr(96, word)
-        }
-        unpackedFillCount = (uint16(uint8(payload[21])) << 8) | uint16(uint8(payload[22]));
-        console.log("UNPACKED HEADER:");
-        console.log("  Filler Address:");
-        console.logAddress(unpackedFiller);
-        console.log("  Fill Count:");
-        console.logUint(unpackedFillCount);
-
-        // For debugging: Log all bytes in the first 23 bytes (header)
-        console.log("HEADER BYTES:");
-        for (uint256 i = 0; i < 23; i++) {
-            console.log(string(abi.encodePacked("  Byte ", uint8(i), ":")));
-            console.logUint(uint8(payload[i]));
-        }
-
-        // Extract and log the order hash from the payload
-        bytes32 extractedHash;
-        assembly {
-            extractedHash := mload(add(add(payload, 32), 23))
-        }
-        console.log("EXTRACTED ORDER HASH:");
-        console.logBytes32(extractedHash);
-        console.log("MATCHES ORIGINAL:", extractedHash == TEST_ORDER_HASH ? "Yes" : "No");
-
-        // Log the full payload in hex
-        console.log("FULL PAYLOAD (hex):");
-        console.logBytes(payload);
-
-        // Verify the fill array is emptied after packing
-        console.log("FILLS ARRAY LENGTH AFTER PACKING:");
-        console.log("  Expected:");
-        console.logUint(0);
-        console.log("  Actual:");
-        console.logUint(wrapper.getFillsLength());
-
-        // Assert using the unpacked values
+        // Assert
         assertEq(payload.length, 55);
         assertEq(uint8(payload[0]), SETTLEMENT_TYPE);
-
-        // Verify filler address with the unpacked value
         assertEq(unpackedFiller, TEST_FILLER);
-
-        // Verify fill count
         assertEq(unpackedFillCount, 1);
-
-        // Verify the fills array is empty after packing (elements were cleared)
         assertEq(wrapper.getFillsLength(), 0);
     }
 
     /// @dev Tests packing a settlement payload with multiple orders
-    /// @notice Covers lines 357-393 in AoriUtils.sol
     function test_packSettlement_multipleOrders() public {
         // Arrange
         uint16 orderCount = 3;
@@ -440,62 +489,17 @@ contract PayloadPackingUnpackingTest is Test {
         address filler = TEST_FILLER;
         uint16 takeSize = orderCount;
 
-        // Log the input data
-        console.log("MULTIPLE ORDERS TEST SETUP:");
-        console.log("  Order Count:", orderCount);
-        console.log("  Filler Address:");
-        console.logAddress(filler);
-
         // Act
         bytes memory payload = wrapper.packSettlement(filler, takeSize);
 
-        // Log the payload type and size
-        console.log("PAYLOAD INFO:");
-        console.log("  Type:", uint8(payload[0]));
-        console.log("  Expected Length:", 23 + takeSize * 32);
-        console.log("  Actual Length:", payload.length);
-
-        // Extract header manually
-        address unpackedFiller;
-        uint16 unpackedFillCount;
-        assembly {
-            let word := mload(add(payload, 33))
-            unpackedFiller := shr(96, word)
-        }
-        unpackedFillCount = (uint16(uint8(payload[21])) << 8) | uint16(uint8(payload[22]));
-        console.log("UNPACKED HEADER:");
-        console.log("  Filler Address:");
-        console.logAddress(unpackedFiller);
-        console.log("  Fill Count:");
-        console.logUint(unpackedFillCount);
-
-        // For debugging: Log all bytes in the first 23 bytes (header)
-        console.log("HEADER BYTES:");
-        for (uint256 i = 0; i < 23; i++) {
-            console.log(string(abi.encodePacked("  Byte ", uint8(i), ":")));
-            console.logUint(uint8(payload[i]));
-        }
-
-        // Log full payload for inspection
-        console.log("FULL PAYLOAD (hex):");
-        console.logBytes(payload);
+        // Validate and unpack using validateAndUnpackSettlement
+        (address unpackedFiller, uint16 unpackedFillCount) = wrapper.validateAndUnpackSettlement(payload);
 
         // Assert
-        // Header: 1 byte type + 20 bytes filler + 2 bytes count = 23 bytes
-        // Body: takeSize * 32 bytes (order hash) = 96 bytes
-        // Total: 23 + 96 = 119 bytes
         assertEq(payload.length, 23 + takeSize * 32);
-
-        // Verify payload type
         assertEq(uint8(payload[0]), SETTLEMENT_TYPE);
-
-        // Verify filler address using unpacked value
         assertEq(unpackedFiller, filler, "Filler address in payload doesn't match expected");
-
-        // Verify fill count using unpacked value
         assertEq(unpackedFillCount, takeSize, "Fill count in payload doesn't match expected");
-
-        // Verify the fills array is empty after packing
         assertEq(wrapper.getFillsLength(), 0);
     }
 
@@ -581,107 +585,17 @@ contract PayloadPackingUnpackingTest is Test {
         address filler = TEST_FILLER;
         uint16 takeSize = orderCount;
 
-        console.log("SETTLEMENT INTEGRATION TEST SETUP:");
-        console.log("  Order Count:");
-        console.logUint(orderCount);
-        console.log("  Filler Address:");
-        console.logAddress(filler);
-
-        // Log the original order hashes
-        console.log("ORIGINAL ORDER HASHES:");
-        for (uint16 i = 0; i < orderCount; i++) {
-            console.log("  Hash", i, ":");
-            console.logBytes32(orderHashes[i]);
-        }
-
         // Act - Pack
         bytes memory payload = wrapper.packSettlement(filler, takeSize);
 
-        // Log the packed payload details
-        console.log("PACKED PAYLOAD:");
-        console.log("  Length:");
-        console.logUint(payload.length);
-        console.log("  Type:");
-        console.logUint(uint8(payload[0]));
-
-        // Extract and log filler address from payload
-        address packedFiller;
-        assembly {
-            packedFiller := shr(96, mload(add(payload, 21)))
-        }
-        console.log("  Packed Filler:");
-        console.logAddress(packedFiller);
-
-        // Extract and log fill count from payload
-        uint16 packedFillCount = (uint16(uint8(payload[21])) << 8) | uint16(uint8(payload[22]));
-        console.log("  Packed Fill Count:");
-        console.logUint(packedFillCount);
-
-        // Log raw payload bytes
-        console.log("RAW PAYLOAD BYTES:");
-        console.logBytes(payload);
-
-        // Perform a byte-by-byte inspection of the header (first 23 bytes)
-        console.log("HEADER BYTE INSPECTION:");
-        console.log("  Type byte (0):");
-        console.logUint(uint8(payload[0]));
-        console.log("  Filler address bytes (1-20):");
-        for (uint256 i = 0; i < 20; i++) {
-            console.log("    Byte");
-            console.logUint(i + 1);
-            console.log(":");
-            console.logUint(uint8(payload[i + 1]));
-        }
-        console.log("  Fill count bytes (21-22):");
-        console.log("    Byte 21:");
-        console.logUint(uint8(payload[21]));
-        console.log("    Byte 22:");
-        console.logUint(uint8(payload[22]));
-
         // Act - Unpack
         PayloadType payloadType = wrapper.getType(payload);
-        address unpackedFiller;
-        uint16 unpackedFillCount;
-        assembly {
-            let word := mload(add(payload, 33))
-            unpackedFiller := shr(96, word)
-        }
-        unpackedFillCount = (uint16(uint8(payload[21])) << 8) | uint16(uint8(payload[22]));
-
-        // Log the unpacked header details
-        console.log("UNPACKED HEADER:");
-        console.log("  Payload Type:");
-        console.logUint(uint8(payloadType));
-        console.log("  Unpacked Filler:");
-        console.logAddress(unpackedFiller);
-        console.log("  Unpacked Fill Count:");
-        console.logUint(unpackedFillCount);
+        (address unpackedFiller, uint16 unpackedFillCount) = wrapper.validateAndUnpackSettlement(payload);
 
         // Get all order hashes
         bytes32[] memory unpackedHashes = new bytes32[](unpackedFillCount);
-        console.log("UNPACKED ORDER HASHES:");
         for (uint16 i = 0; i < unpackedFillCount; i++) {
             unpackedHashes[i] = wrapper.unpackSettlementBodyAt(payload, i);
-            console.log("  Hash");
-            console.logUint(i);
-            console.log(":");
-            console.logBytes32(unpackedHashes[i]);
-        }
-
-        // Check how the expected order hashes should map to unpacked order hashes
-        console.log("ORDER HASH MAPPING CHECK:");
-        for (uint16 i = 0; i < unpackedFillCount; i++) {
-            console.log("  Original[");
-            console.logUint(orderCount - i - 1);
-            console.log("] should match Unpacked[");
-            console.logUint(i);
-            console.log("]:");
-            console.logBytes32(orderHashes[orderCount - i - 1]);
-            console.logBytes32(unpackedHashes[i]);
-
-            bool matches = orderHashes[orderCount - i - 1] == unpackedHashes[i];
-            console.log("  Match:");
-            console.logString(matches ? "Yes" : "No");
         }
 
         // Assert
@@ -689,10 +603,8 @@ contract PayloadPackingUnpackingTest is Test {
         assertEq(unpackedFiller, filler);
         assertEq(unpackedFillCount, takeSize);
 
-        // Verify all hashes match
+        // Verify all hashes match (packed in reverse order from the end of the array)
         for (uint16 i = 0; i < unpackedFillCount; i++) {
-            // We packed the hashes in reverse order (from the end of the array)
-            // So the first unpacked hash is the last hash in the original array, etc.
             assertEq(unpackedHashes[i], orderHashes[orderCount - i - 1]);
         }
     }


### PR DESCRIPTION
The `validateAndUnpackSettlement()` function consolidated the `validateSettlementLen()` functions and the `unpackSettlementHeader()`. These functions were left in `PayloadUtils.sol` as dead code