### PR TITLE
3.2 - Event Cleanup

### DIFF
--- a/contracts/Aori.sol
+++ b/contracts/Aori.sol
@@ -493,9 +493,9 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, PausableUpgradeable, UUPSU
 
         // Update contract state
         if (order.isSingleChainSwap()) {
-            AoriSettleLib.settleSingleChainSwap(orderId, order, msg.sender, address(0), 0, 0);
+            AoriSettleLib.settleSingleChainSwap(orderId, order, msg.sender, order.outputToken, order.outputAmount, 0);
         } else {
-            _postFill(orderId, order, address(0), 0, 0);
+            _postFill(orderId, order, order.outputToken, order.outputAmount, 0);
         }
 
         // Transfer tokens to recipient
@@ -554,21 +554,21 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, PausableUpgradeable, UUPSU
      * @notice Processes an order after successful filling
      * @param orderId The unique identifier for the order
      * @param order The order details that were filled
-     * @param dstHookTokenIn The token used in dstHook (address(0) if no hook)
-     * @param dstHookAmountIn The amount sent to dstHook (0 if no hook)
-     * @param dstHookAmountOut The amount received from dstHook (0 if no hook)
+     * @param fillToken The token the solver spent to fill (outputToken if direct, hook.preferredToken if via hook)
+     * @param fillAmount The amount the solver spent to fill
+     * @param fillAmountOut The amount of outputToken produced by hook (0 if direct transfer)
      */
     function _postFill(
         bytes32 orderId,
         Order calldata order,
-        address dstHookTokenIn,
-        uint256 dstHookAmountIn,
-        uint256 dstHookAmountOut
+        address fillToken,
+        uint256 fillAmount,
+        uint256 fillAmountOut
     ) internal {
         AoriStorageData storage $ = _getAoriStorage();
         $.orderStatus[orderId] = OrderStatus.Filled;
         $.srcEidToFillerFills[order.srcEid][msg.sender].push(orderId);
-        emit Fill(orderId, dstHookTokenIn, dstHookAmountIn, dstHookAmountOut);
+        emit Fill(orderId, fillToken, fillAmount, fillAmountOut);
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/

--- a/contracts/interfaces/IAori.sol
+++ b/contracts/interfaces/IAori.sol
@@ -25,17 +25,17 @@ interface IAori {
     );
 
     /**
-     * @notice Emitted when a solver fills an order on the destination chain
+     * @notice Emitted when a solver fills an order
      * @param orderId The unique hash identifying the order
-     * @param dstHookTokenIn The token sent to the destination hook (address(0) if no hook)
-     * @param dstHookAmountIn The amount sent to the destination hook (0 if no hook)
-     * @param dstHookAmountOut The amount of output tokens received from the hook (0 if no hook)
+     * @param fillToken The token the solver spent to fill (address(0) if atomic swap, no solver cost)
+     * @param fillAmount The amount the solver spent to fill (0 if atomic swap)
+     * @param fillAmountOut The amount of outputToken produced by hook conversion (0 if direct transfer, no hook)
      */
     event Fill(
         bytes32 indexed orderId, 
-        address indexed dstHookTokenIn, 
-        uint256 dstHookAmountIn, 
-        uint256 dstHookAmountOut
+        address indexed fillToken, 
+        uint256 fillAmount, 
+        uint256 fillAmountOut
     );
 
     /**

--- a/contracts/lib/AoriAtomicSwapLib.sol
+++ b/contracts/lib/AoriAtomicSwapLib.sol
@@ -67,7 +67,7 @@ library AoriAtomicSwapLib {
         // Execute hook - converts input to output, validates minOutput
         amountReceived = HookUtils.executeHook(hook.hookAddress, hook.instructions, order.outputToken, minOutput);
 
-        _distributeOutputs($, orderId, order, hook.preferredToken, solver, amountReceived);
+        _distributeOutputs($, orderId, order, solver, amountReceived);
     }
 
     /**
@@ -78,7 +78,6 @@ library AoriAtomicSwapLib {
         AoriStorageData storage $,
         bytes32 orderId,
         Order calldata order,
-        address preferredToken,
         address solver,
         uint256 amountReceived
     ) internal {
@@ -108,7 +107,7 @@ library AoriAtomicSwapLib {
             $.balances[solver][order.outputToken].unlocked += SafeCast.toUint128(surplus);
         }
 
-        emit IAori.Deposit(orderId, order, preferredToken, amountReceived);
+        emit IAori.Deposit(orderId, order, order.outputToken, amountReceived);
         emit IAori.Fill(orderId, address(0), 0, 0);
         emit IAori.Settle(orderId, solver, SafeCast.toUint128(surplus), protocolFee, actualFeeRecipient, additionalFee);
     }

--- a/contracts/lib/AoriSettleLib.sol
+++ b/contracts/lib/AoriSettleLib.sol
@@ -49,17 +49,17 @@ library AoriSettleLib {
      * @param orderId The unique identifier for the order
      * @param order The order details
      * @param solver The address of the solver who filled the order
-     * @param dstHookTokenIn The token used in dstHook (address(0) if no hook)
-     * @param dstHookAmountIn The amount sent to dstHook (0 if no hook)
-     * @param dstHookAmountOut The amount received from dstHook (0 if no hook)
+     * @param fillToken The token the solver spent to fill (outputToken if direct, hook.preferredToken if via hook)
+     * @param fillAmount The amount the solver spent to fill
+     * @param fillAmountOut The amount of outputToken produced by hook (0 if direct transfer)
      */
     function settleSingleChainSwap(
         bytes32 orderId,
         Order memory order,
         address solver,
-        address dstHookTokenIn,
-        uint256 dstHookAmountIn,
-        uint256 dstHookAmountOut
+        address fillToken,
+        uint256 fillAmount,
+        uint256 fillAmountOut
     ) external {
         AoriStorageData storage $ = _getAoriStorage();
 
@@ -84,7 +84,7 @@ library AoriSettleLib {
         }
 
         $.orderStatus[orderId] = OrderStatus.Settled;
-        emit IAori.Fill(orderId, dstHookTokenIn, dstHookAmountIn, dstHookAmountOut);
+        emit IAori.Fill(orderId, fillToken, fillAmount, fillAmountOut);
         emit IAori.Settle(orderId, solver, solverAmount, protocolFee, feeRecipient, additionalFee);
     }
 

--- a/test/foundry/SC_NativeToERC20NoHook.t.sol
+++ b/test/foundry/SC_NativeToERC20NoHook.t.sol
@@ -405,9 +405,9 @@ contract SC_NativeToERC20NoHook_Test is TestUtils {
         vm.prank(solverSC);
         outputToken.approve(address(localAori), OUTPUT_AMOUNT);
 
-        // Expect Fill event (no dstHook)
+        // Expect Fill event (no dstHook — emits solver's direct cost)
         vm.expectEmit(true, true, false, true);
-        emit IAori.Fill(orderId, address(0), 0, 0);
+        emit IAori.Fill(orderId, address(outputToken), OUTPUT_AMOUNT, 0);
 
         vm.expectEmit(true, true, false, false);
         emit IAori.Settle(orderId, solverSC, 0, 0, address(0), 0);


### PR DESCRIPTION
## Standardized Event Schema 

`_distributeOutputs` emitted `hook.preferredToken` in the Deposit event instead of `order.outputToken` — the token actually produced by the hook. Fixed by removing the `preferredToken` parameter entirely and emitting `order.outputToken` directly.

Renamed Fill event fields from:
 `dstHookTokenIn` -> `fillToken`
 `dstHookAmountIn` -> `fillAmount`
 `dstHookAmountOut` -> `fillAmountOut` 
to accurately reflect their generalized meaning across all order types — not just dstHook fills.

Changed no-hook fill paths to emit the solver's actual cost (`outputToken`, `outputAmount`, `0`) instead of zeros, so the Fill event always captures what the solver spent regardless of whether a hook was used.

These changes enable a single dollarized solver PnL formula across every execution path (atomic, no-hook, dstHook, cross-chain)