### PR TITLE
feat: add operator role with onlyOwnerOrOperator access control

### DIFF
--- a/contracts/Aori.sol
+++ b/contracts/Aori.sol
@@ -113,7 +113,8 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, PausableUpgradeable, UUPSU
         uint16 _maxFillsPerSettle,
         address[] calldata _initialSolvers,
         address[] calldata _initialHooks,
-        uint32[] calldata _supportedChains
+        uint32[] calldata _supportedChains,
+        address[] calldata _initialOperators
     ) external initializer {
         if (_owner == address(0)) revert InvalidOwner();
         __Ownable_init(_owner);
@@ -132,6 +133,9 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, PausableUpgradeable, UUPSU
         }
         for (uint256 i = 0; i < _supportedChains.length; i++) {
             $.isSupportedChain[_supportedChains[i]] = true;
+        }
+        for (uint256 i = 0; i < _initialOperators.length; i++) {
+            $.isOperator[_initialOperators[i]] = true;
         }
 
         $.maxFeeMbps = 1000; // Default 1% max additional fee
@@ -161,6 +165,9 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, PausableUpgradeable, UUPSU
     
     /// @notice Returns whether a solver address is whitelisted
     function isAllowedSolver(address solver) public view returns (bool) { return _getAoriStorage().isAllowedSolver[solver]; }
+
+    /// @notice Check if an address is an operator
+    function isOperator(address addr) external view returns (bool) { return _getAoriStorage().isOperator[addr]; }
     
     /// @notice Reads a raw storage slot value (for off-chain introspection)
     function readStorage(bytes32 slot) external view returns (bytes32 value) { assembly { value := sload(slot) } }
@@ -194,22 +201,34 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, PausableUpgradeable, UUPSU
     function unpause() external onlyOwner { _unpause(); }
 
     /// @notice Add a hook to the whitelist
-    function addAllowedHook(address hook) external onlyOwner { _getAoriStorage().isAllowedHook[hook] = true; emit HookAdded(hook); }
+    function addAllowedHook(address hook) external onlyOwnerOrOperator { _getAoriStorage().isAllowedHook[hook] = true; emit HookAdded(hook); }
     
     /// @notice Remove a hook from the whitelist
-    function removeAllowedHook(address hook) external onlyOwner { _getAoriStorage().isAllowedHook[hook] = false; emit HookRemoved(hook); }
+    function removeAllowedHook(address hook) external onlyOwnerOrOperator { _getAoriStorage().isAllowedHook[hook] = false; emit HookRemoved(hook); }
     
     /// @notice Add a solver to the whitelist
-    function addAllowedSolver(address solver) external onlyOwner { _getAoriStorage().isAllowedSolver[solver] = true; emit SolverAdded(solver); }
+    function addAllowedSolver(address solver) external onlyOwnerOrOperator { _getAoriStorage().isAllowedSolver[solver] = true; emit SolverAdded(solver); }
     
     /// @notice Remove a solver from the whitelist
-    function removeAllowedSolver(address solver) external onlyOwner { _getAoriStorage().isAllowedSolver[solver] = false; emit SolverRemoved(solver); }
+    function removeAllowedSolver(address solver) external onlyOwnerOrOperator { _getAoriStorage().isAllowedSolver[solver] = false; emit SolverRemoved(solver); }
     
     /// @notice Add a chain to the supported chains list
-    function addSupportedChain(uint32 eid) external onlyOwner { _getAoriStorage().isSupportedChain[eid] = true; emit ChainSupported(eid); }
+    function addSupportedChain(uint32 eid) external onlyOwnerOrOperator { _getAoriStorage().isSupportedChain[eid] = true; emit ChainSupported(eid); }
     
     /// @notice Remove a chain from the supported chains list
-    function removeSupportedChain(uint32 eid) external onlyOwner { _getAoriStorage().isSupportedChain[eid] = false; emit ChainRemoved(eid); }
+    function removeSupportedChain(uint32 eid) external onlyOwnerOrOperator { _getAoriStorage().isSupportedChain[eid] = false; emit ChainRemoved(eid); }
+
+    /// @notice Add an operator
+    function addOperator(address operator) external onlyOwner { _getAoriStorage().isOperator[operator] = true; emit OperatorAdded(operator); }
+
+    /// @notice Remove an operator
+    function removeOperator(address operator) external onlyOwner { _getAoriStorage().isOperator[operator] = false; emit OperatorRemoved(operator); }
+
+    /// @notice Override OApp's setPeer to allow operator access
+    function setPeer(uint32 _eid, bytes32 _peer) public override onlyOwnerOrOperator {
+        _getOAppCoreStorage().peers[_eid] = _peer;
+        emit PeerSet(_eid, _peer);
+    }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                   ADMIN LIB FUNCTIONS                      */
@@ -229,10 +248,10 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, PausableUpgradeable, UUPSU
     function claimProtocolFees(address token) external nonReentrant { AoriAdminLib.claimProtocolFees(token); }
 
     /// @notice Sets the protocol fee in millibasis points (cross-validated with maxFeeMbps)
-    function setProtocolFee(uint16 feeMbps) external onlyOwner { AoriAdminLib.setProtocolFee(feeMbps); }
+    function setProtocolFee(uint16 feeMbps) external onlyOwnerOrOperator { AoriAdminLib.setProtocolFee(feeMbps); }
 
     /// @notice Sets the protocol treasury address that receives protocol fees
-    function setProtocolTreasury(address treasury) external onlyOwner { AoriAdminLib.setProtocolTreasury(treasury); }
+    function setProtocolTreasury(address treasury) external onlyOwnerOrOperator { AoriAdminLib.setProtocolTreasury(treasury); }
 
     /// @notice Returns the current protocol fee and treasury address
     function getProtocolConfig() external view returns (uint16 feeMbps, address treasury) { return AoriAdminLib.getProtocolConfig(); }
@@ -241,13 +260,13 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, PausableUpgradeable, UUPSU
     function getPendingProtocolFees(address token) external view returns (uint256) { return AoriAdminLib.getPendingProtocolFees(token); }
 
     /// @notice Sets the maximum allowed additional fee in millibasis points (cross-validated with protocolFeeMbps)
-    function setMaxFee(uint16 maxFeeMbps) external onlyOwner { AoriAdminLib.setMaxFee(maxFeeMbps); }
+    function setMaxFee(uint16 maxFeeMbps) external onlyOwnerOrOperator { AoriAdminLib.setMaxFee(maxFeeMbps); }
 
     /// @notice Returns the current maximum allowed additional fee
     function getMaxFee() external view returns (uint16) { return AoriAdminLib.getMaxFee(); }
 
     /// @notice Sets the maximum number of fills processed per settlement batch
-    function setMaxFillsPerSettle(uint16 maxFills) external onlyOwner { AoriAdminLib.setMaxFillsPerSettle(maxFills); }
+    function setMaxFillsPerSettle(uint16 maxFills) external onlyOwnerOrOperator { AoriAdminLib.setMaxFillsPerSettle(maxFills); }
 
     /// @notice Returns the current maximum fills per settlement batch
     function getMaxFillsPerSettle() external view returns (uint16) { return AoriAdminLib.getMaxFillsPerSettle(); }
@@ -263,6 +282,21 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, PausableUpgradeable, UUPSU
     modifier onlySolver() {
         if (!_getAoriStorage().isAllowedSolver[msg.sender]) revert InvalidSolver();
         _;
+    }
+
+    /**
+     * @notice Modifier to ensure the caller is the owner or an operator
+     * @dev Uses internal function to minimize bytecode duplication across 11 callsites
+     */
+    modifier onlyOwnerOrOperator() {
+        _checkOwnerOrOperator();
+        _;
+    }
+
+    function _checkOwnerOrOperator() internal view {
+        if (msg.sender != owner() && !_getAoriStorage().isOperator[msg.sender]) {
+            revert Unauthorized();
+        }
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/

--- a/contracts/Aori.sol
+++ b/contracts/Aori.sol
@@ -166,7 +166,7 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, PausableUpgradeable, UUPSU
     /// @notice Returns whether a solver address is whitelisted
     function isAllowedSolver(address solver) public view returns (bool) { return _getAoriStorage().isAllowedSolver[solver]; }
 
-    /// @notice Check if an address is an operator
+    /// @notice Returns whether an address is an operator
     function isOperator(address addr) external view returns (bool) { return _getAoriStorage().isOperator[addr]; }
     
     /// @notice Reads a raw storage slot value (for off-chain introspection)
@@ -286,7 +286,7 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, PausableUpgradeable, UUPSU
 
     /**
      * @notice Modifier to ensure the caller is the owner or an operator
-     * @dev Uses internal function to minimize bytecode duplication across 11 callsites
+     * @dev Uses internal function to minimize bytecode duplication across callsites
      */
     modifier onlyOwnerOrOperator() {
         _checkOwnerOrOperator();
@@ -294,9 +294,7 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, PausableUpgradeable, UUPSU
     }
 
     function _checkOwnerOrOperator() internal view {
-        if (msg.sender != owner() && !_getAoriStorage().isOperator[msg.sender]) {
-            revert Unauthorized();
-        }
+        if (msg.sender != owner() && !_getAoriStorage().isOperator[msg.sender]) revert Unauthorized();
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/

--- a/contracts/AoriLens.sol
+++ b/contracts/AoriLens.sol
@@ -116,14 +116,13 @@ contract AoriLens {
     }
 
     /**
-     * @notice Check if an address is an operator
+     * @notice Returns whether an address is an operator
      */
     function isOperator(
         address addr
     ) external view returns (bool) {
         bytes32 slot = keccak256(abi.encode(addr, uint256(AORI_STORAGE_SLOT) + IS_OPERATOR_OFFSET));
-        bytes32 value = aori.readStorage(slot);
-        return uint256(value) != 0;
+        return uint256(aori.readStorage(slot)) != 0;
     }
 
     /**

--- a/contracts/AoriLens.sol
+++ b/contracts/AoriLens.sol
@@ -56,6 +56,7 @@ contract AoriLens {
     uint256 constant IS_ALLOWED_HOOK_OFFSET = 5;
     uint256 constant IS_ALLOWED_SOLVER_OFFSET = 6;
     uint256 constant SRC_EID_TO_FILLER_FILLS_OFFSET = 7;
+    uint256 constant IS_OPERATOR_OFFSET = 12;
 
     IAoriLensTarget public immutable aori;
 
@@ -112,6 +113,17 @@ contract AoriLens {
 
         // Slot 7: Options.dstSolver (lower 160)
         order.options.dstSolver = address(uint160(uint256(slot7)));
+    }
+
+    /**
+     * @notice Check if an address is an operator
+     */
+    function isOperator(
+        address addr
+    ) external view returns (bool) {
+        bytes32 slot = keccak256(abi.encode(addr, uint256(AORI_STORAGE_SLOT) + IS_OPERATOR_OFFSET));
+        bytes32 value = aori.readStorage(slot);
+        return uint256(value) != 0;
     }
 
     /**

--- a/contracts/AoriStorage.sol
+++ b/contracts/AoriStorage.sol
@@ -48,6 +48,9 @@ struct AoriStorageData {
     address protocolTreasury; // receives protocol fees
     mapping(address => uint256) pendingProtocolFees; // Accumulated protocol fees per token
     uint16 maxFeeMbps; // Maximum allowed additional fee in millibasis points
+
+    // OPERATOR STATE
+    mapping(address => bool) isOperator;
 }
 
 /**

--- a/contracts/interfaces/IAori.sol
+++ b/contracts/interfaces/IAori.sol
@@ -150,6 +150,18 @@ interface IAori {
      */
     event ProtocolFeesClaimed(address indexed token, uint256 amount, address indexed treasury);
 
+    /**
+     * @notice Emitted when an operator is added
+     * @param operator The address of the operator added
+     */
+    event OperatorAdded(address indexed operator);
+
+    /**
+     * @notice Emitted when an operator is removed
+     * @param operator The address of the operator removed
+     */
+    event OperatorRemoved(address indexed operator);
+
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                          LZ EVENTS                        */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
@@ -216,6 +228,8 @@ interface IAori {
     function getMaxFee() external view returns (uint16 maxFeeMbps);
 
     function getMaxFillsPerSettle() external view returns (uint16);
+
+    function isOperator(address addr) external view returns (bool);
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                        SRC FUNCTIONS                       */
@@ -297,4 +311,8 @@ interface IAori {
     function setMaxFee(uint16 maxFeeMbps) external;
 
     function setMaxFillsPerSettle(uint16 maxFills) external;
+
+    function addOperator(address operator) external;
+
+    function removeOperator(address operator) external;
 }

--- a/contracts/types/AoriErrors.sol
+++ b/contracts/types/AoriErrors.sol
@@ -230,3 +230,10 @@ error NoPendingFees();
 
 /// @notice Thrown when combined protocol fee and max additional fee would exceed 100%
 error CombinedFeesTooHigh();
+
+/*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+/*                    ACCESS CONTROL ERRORS                     */
+/*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+/// @notice Thrown when caller is not the owner or an operator
+error Unauthorized();

--- a/script/BaseScript.sol
+++ b/script/BaseScript.sol
@@ -334,7 +334,7 @@ abstract contract BaseScript is Script {
         console.log("Implementation deployed via CREATE3 at:", implementation);
 
         // Deploy proxy via CREATE3
-        bytes memory initData = abi.encodeCall(Aori.initialize, (owner, maxFillsPerSettle, initialSolvers, initialHooks, supportedChains));
+        bytes memory initData = abi.encodeCall(Aori.initialize, (owner, maxFillsPerSettle, initialSolvers, initialHooks, supportedChains, new address[](0)));
         bytes memory proxyBytecode = abi.encodePacked(type(ERC1967Proxy).creationCode, abi.encode(implementation, initData));
         address proxy = _deployCreate3(proxySalt, proxyBytecode);
         console.log("Proxy deployed via CREATE3 at:", proxy);

--- a/test/foundry/22_HashVerificationTest.t.sol
+++ b/test/foundry/22_HashVerificationTest.t.sol
@@ -139,7 +139,7 @@ contract HashVerificationTest is TestUtils {
         ERC1967Proxy proxy = new ERC1967Proxy(
             address(implementation),
             abi.encodeCall(
-                implementation.initialize, (address(this), MAX_FILLS_PER_SETTLE, new address[](0), new address[](0), new uint32[](0))
+                implementation.initialize, (address(this), MAX_FILLS_PER_SETTLE, new address[](0), new address[](0), new uint32[](0), new address[](0))
             )
         );
 
@@ -153,7 +153,7 @@ contract HashVerificationTest is TestUtils {
         vm.store(ARBITRUM_CONTRACT_ADDRESS, implSlot, bytes32(uint256(uint160(address(implementation)))));
 
         // Initialize the etched contract
-        Aori(ARBITRUM_CONTRACT_ADDRESS).initialize(address(this), MAX_FILLS_PER_SETTLE, new address[](0), new address[](0), new uint32[](0));
+        Aori(ARBITRUM_CONTRACT_ADDRESS).initialize(address(this), MAX_FILLS_PER_SETTLE, new address[](0), new address[](0), new uint32[](0), new address[](0));
 
         // ADD THIS CODE HERE - before any deposit operations
         vm.startPrank(address(this));

--- a/test/foundry/36_Upgrade.t.sol
+++ b/test/foundry/36_Upgrade.t.sol
@@ -93,7 +93,7 @@ contract UpgradeTests is TestHelperOz5 {
 
         // Deploy proxy with initialization
         bytes memory initData =
-            abi.encodeCall(Aori.initialize, (owner, MAX_FILLS_PER_SETTLE, initialSolvers, initialHooks, supportedChains));
+            abi.encodeCall(Aori.initialize, (owner, MAX_FILLS_PER_SETTLE, initialSolvers, initialHooks, supportedChains, new address[](0)));
 
         proxy = new ERC1967Proxy(address(implementation), initData);
         aori = Aori(payable(address(proxy)));
@@ -189,7 +189,7 @@ contract UpgradeTests is TestHelperOz5 {
         uint32[] memory emptyChains = new uint32[](0);
 
         vm.expectRevert();
-        aori.initialize(nonOwner, 5, emptySolvers, emptyHooks, emptyChains);
+        aori.initialize(nonOwner, 5, emptySolvers, emptyHooks, emptyChains, new address[](0));
     }
 
     /**
@@ -201,7 +201,7 @@ contract UpgradeTests is TestHelperOz5 {
         uint32[] memory emptyChains = new uint32[](0);
 
         vm.expectRevert();
-        implementation.initialize(owner, MAX_FILLS_PER_SETTLE, emptySolvers, emptyHooks, emptyChains);
+        implementation.initialize(owner, MAX_FILLS_PER_SETTLE, emptySolvers, emptyHooks, emptyChains, new address[](0));
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/

--- a/test/foundry/39_OperatorTests.t.sol
+++ b/test/foundry/39_OperatorTests.t.sol
@@ -1,0 +1,378 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.34;
+
+import "forge-std/Test.sol";
+import "../../contracts/Aori.sol";
+import "../../contracts/interfaces/IAori.sol";
+import "./TestUtils.sol";
+
+contract OperatorTests is TestUtils {
+    address constant OPERATOR = address(0x4444);
+    address constant OPERATOR2 = address(0x5555);
+    address constant NON_OWNER = address(0x3333);
+    address constant TEST_HOOK = address(0x1111);
+    address constant TEST_SOLVER = address(0x2222);
+    uint32 constant TEST_EID = 12345;
+
+    event OperatorAdded(address indexed operator);
+    event OperatorRemoved(address indexed operator);
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                  OPERATOR MANAGEMENT                         */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    function testAddOperator_Success() public {
+        assertFalse(localAori.isOperator(OPERATOR));
+        vm.prank(address(this));
+        vm.expectEmit(true, false, false, false);
+        emit OperatorAdded(OPERATOR);
+        localAori.addOperator(OPERATOR);
+        assertTrue(localAori.isOperator(OPERATOR));
+    }
+
+    function testAddOperator_OnlyOwner() public {
+        vm.prank(NON_OWNER);
+        vm.expectRevert();
+        localAori.addOperator(OPERATOR);
+        assertFalse(localAori.isOperator(OPERATOR));
+    }
+
+    function testAddOperator_OperatorCannotAddOperator() public {
+        vm.prank(address(this));
+        localAori.addOperator(OPERATOR);
+
+        vm.prank(OPERATOR);
+        vm.expectRevert();
+        localAori.addOperator(OPERATOR2);
+    }
+
+    function testRemoveOperator_Success() public {
+        vm.prank(address(this));
+        localAori.addOperator(OPERATOR);
+        assertTrue(localAori.isOperator(OPERATOR));
+
+        vm.prank(address(this));
+        vm.expectEmit(true, false, false, false);
+        emit OperatorRemoved(OPERATOR);
+        localAori.removeOperator(OPERATOR);
+        assertFalse(localAori.isOperator(OPERATOR));
+    }
+
+    function testRemoveOperator_OnlyOwner() public {
+        vm.prank(address(this));
+        localAori.addOperator(OPERATOR);
+
+        vm.prank(NON_OWNER);
+        vm.expectRevert();
+        localAori.removeOperator(OPERATOR);
+        assertTrue(localAori.isOperator(OPERATOR));
+    }
+
+    function testRemoveOperator_OperatorCannotRemoveSelf() public {
+        vm.prank(address(this));
+        localAori.addOperator(OPERATOR);
+
+        vm.prank(OPERATOR);
+        vm.expectRevert();
+        localAori.removeOperator(OPERATOR);
+        assertTrue(localAori.isOperator(OPERATOR));
+    }
+
+    function testMultipleOperators() public {
+        vm.startPrank(address(this));
+        localAori.addOperator(OPERATOR);
+        localAori.addOperator(OPERATOR2);
+        vm.stopPrank();
+
+        assertTrue(localAori.isOperator(OPERATOR));
+        assertTrue(localAori.isOperator(OPERATOR2));
+
+        vm.prank(address(this));
+        localAori.removeOperator(OPERATOR);
+
+        assertFalse(localAori.isOperator(OPERATOR));
+        assertTrue(localAori.isOperator(OPERATOR2));
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*              OPERATOR CAN CALL OPERATIONAL FUNCTIONS          */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    function testOperator_AddAllowedSolver() public {
+        vm.prank(address(this));
+        localAori.addOperator(OPERATOR);
+
+        vm.prank(OPERATOR);
+        localAori.addAllowedSolver(TEST_SOLVER);
+        assertTrue(localAori.isAllowedSolver(TEST_SOLVER));
+    }
+
+    function testOperator_RemoveAllowedSolver() public {
+        vm.startPrank(address(this));
+        localAori.addOperator(OPERATOR);
+        localAori.addAllowedSolver(TEST_SOLVER);
+        vm.stopPrank();
+
+        vm.prank(OPERATOR);
+        localAori.removeAllowedSolver(TEST_SOLVER);
+        assertFalse(localAori.isAllowedSolver(TEST_SOLVER));
+    }
+
+    function testOperator_AddAllowedHook() public {
+        vm.prank(address(this));
+        localAori.addOperator(OPERATOR);
+
+        vm.prank(OPERATOR);
+        localAori.addAllowedHook(TEST_HOOK);
+        assertTrue(localAori.isAllowedHook(TEST_HOOK));
+    }
+
+    function testOperator_RemoveAllowedHook() public {
+        vm.startPrank(address(this));
+        localAori.addOperator(OPERATOR);
+        localAori.addAllowedHook(TEST_HOOK);
+        vm.stopPrank();
+
+        vm.prank(OPERATOR);
+        localAori.removeAllowedHook(TEST_HOOK);
+        assertFalse(localAori.isAllowedHook(TEST_HOOK));
+    }
+
+    function testOperator_AddSupportedChain() public {
+        vm.prank(address(this));
+        localAori.addOperator(OPERATOR);
+
+        vm.prank(OPERATOR);
+        localAori.addSupportedChain(TEST_EID);
+        assertTrue(localAori.isSupportedChain(TEST_EID));
+    }
+
+    function testOperator_RemoveSupportedChain() public {
+        vm.startPrank(address(this));
+        localAori.addOperator(OPERATOR);
+        localAori.addSupportedChain(TEST_EID);
+        vm.stopPrank();
+
+        vm.prank(OPERATOR);
+        localAori.removeSupportedChain(TEST_EID);
+        assertFalse(localAori.isSupportedChain(TEST_EID));
+    }
+
+    function testOperator_SetPeer() public {
+        vm.prank(address(this));
+        localAori.addOperator(OPERATOR);
+
+        bytes32 peer = bytes32(uint256(uint160(address(0xBEEF))));
+        vm.prank(OPERATOR);
+        localAori.setPeer(TEST_EID, peer);
+    }
+
+    function testOperator_SetMaxFillsPerSettle() public {
+        vm.prank(address(this));
+        localAori.addOperator(OPERATOR);
+
+        vm.prank(OPERATOR);
+        localAori.setMaxFillsPerSettle(20);
+    }
+
+    function testOperator_SetProtocolFee() public {
+        vm.prank(address(this));
+        localAori.addOperator(OPERATOR);
+
+        vm.prank(OPERATOR);
+        localAori.setProtocolFee(50);
+    }
+
+    function testOperator_SetProtocolTreasury() public {
+        vm.prank(address(this));
+        localAori.addOperator(OPERATOR);
+
+        vm.prank(OPERATOR);
+        localAori.setProtocolTreasury(OPERATOR2);
+    }
+
+    function testOperator_SetMaxFee() public {
+        vm.prank(address(this));
+        localAori.addOperator(OPERATOR);
+
+        vm.prank(OPERATOR);
+        localAori.setMaxFee(500);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*            OPERATOR CANNOT CALL CRITICAL FUNCTIONS            */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    function testOperator_CannotPause() public {
+        vm.prank(address(this));
+        localAori.addOperator(OPERATOR);
+
+        vm.prank(OPERATOR);
+        vm.expectRevert();
+        localAori.pause();
+    }
+
+    function testOperator_CannotUnpause() public {
+        vm.prank(address(this));
+        localAori.pause();
+
+        vm.prank(address(this));
+        localAori.addOperator(OPERATOR);
+
+        vm.prank(OPERATOR);
+        vm.expectRevert();
+        localAori.unpause();
+    }
+
+    function testOperator_CannotEmergencyCancel() public {
+        vm.prank(address(this));
+        localAori.addOperator(OPERATOR);
+
+        vm.prank(OPERATOR);
+        vm.expectRevert();
+        localAori.emergencyCancel(bytes32(0), address(this));
+    }
+
+    function testOperator_CannotEmergencyWithdraw() public {
+        vm.prank(address(this));
+        localAori.addOperator(OPERATOR);
+
+        vm.prank(OPERATOR);
+        vm.expectRevert();
+        localAori.emergencyWithdraw(address(inputToken), 0, address(this));
+    }
+
+    function testOperator_CannotEmergencyWithdrawFromBalance() public {
+        vm.prank(address(this));
+        localAori.addOperator(OPERATOR);
+
+        vm.prank(OPERATOR);
+        vm.expectRevert();
+        localAori.emergencyWithdrawFromBalance(address(inputToken), 0, userA, true, address(this));
+    }
+
+    function testOperator_CannotTransferOwnership() public {
+        vm.prank(address(this));
+        localAori.addOperator(OPERATOR);
+
+        vm.prank(OPERATOR);
+        vm.expectRevert();
+        localAori.transferOwnership(OPERATOR);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*            NON-OWNER NON-OPERATOR CANNOT CALL                */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    function testNonOwnerNonOperator_CannotCallOperationalFunctions() public {
+        vm.startPrank(NON_OWNER);
+
+        vm.expectRevert();
+        localAori.addAllowedSolver(TEST_SOLVER);
+
+        vm.expectRevert();
+        localAori.removeAllowedSolver(TEST_SOLVER);
+
+        vm.expectRevert();
+        localAori.addAllowedHook(TEST_HOOK);
+
+        vm.expectRevert();
+        localAori.removeAllowedHook(TEST_HOOK);
+
+        vm.expectRevert();
+        localAori.addSupportedChain(TEST_EID);
+
+        vm.expectRevert();
+        localAori.removeSupportedChain(TEST_EID);
+
+        vm.expectRevert();
+        localAori.setPeer(TEST_EID, bytes32(0));
+
+        vm.expectRevert();
+        localAori.setMaxFillsPerSettle(20);
+
+        vm.expectRevert();
+        localAori.setProtocolFee(50);
+
+        vm.expectRevert();
+        localAori.setProtocolTreasury(NON_OWNER);
+
+        vm.expectRevert();
+        localAori.setMaxFee(500);
+
+        vm.stopPrank();
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*             OWNER CAN STILL CALL OPERATIONAL                 */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    function testOwner_CanStillCallOperationalFunctions() public {
+        vm.startPrank(address(this));
+        localAori.addAllowedSolver(TEST_SOLVER);
+        assertTrue(localAori.isAllowedSolver(TEST_SOLVER));
+
+        localAori.addAllowedHook(TEST_HOOK);
+        assertTrue(localAori.isAllowedHook(TEST_HOOK));
+
+        localAori.addSupportedChain(TEST_EID);
+        assertTrue(localAori.isSupportedChain(TEST_EID));
+
+        localAori.setMaxFillsPerSettle(20);
+        localAori.setProtocolFee(50);
+        localAori.setProtocolTreasury(address(0xBEEF));
+        localAori.setMaxFee(500);
+
+        vm.stopPrank();
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                REVOKED OPERATOR LOSES ACCESS                 */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    function testRevokedOperator_LosesAccess() public {
+        vm.startPrank(address(this));
+        localAori.addOperator(OPERATOR);
+        vm.stopPrank();
+
+        // Operator can call
+        vm.prank(OPERATOR);
+        localAori.addAllowedSolver(TEST_SOLVER);
+        assertTrue(localAori.isAllowedSolver(TEST_SOLVER));
+
+        // Revoke operator
+        vm.prank(address(this));
+        localAori.removeOperator(OPERATOR);
+
+        // Operator can no longer call
+        vm.prank(OPERATOR);
+        vm.expectRevert();
+        localAori.removeAllowedSolver(TEST_SOLVER);
+
+        // Solver still there (revoke didn't affect state)
+        assertTrue(localAori.isAllowedSolver(TEST_SOLVER));
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                  INITIALIZE WITH OPERATORS                   */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    function testInitializeWithOperators() public {
+        address[] memory operators = new address[](2);
+        operators[0] = OPERATOR;
+        operators[1] = OPERATOR2;
+
+        Aori impl = new Aori(address(endpoints[localEid]), localEid);
+        ERC1967Proxy proxy = new ERC1967Proxy(
+            address(impl),
+            abi.encodeCall(
+                Aori.initialize, (address(this), MAX_FILLS_PER_SETTLE, new address[](0), new address[](0), new uint32[](0), operators)
+            )
+        );
+        Aori aori = Aori(payable(address(proxy)));
+
+        assertTrue(aori.isOperator(OPERATOR));
+        assertTrue(aori.isOperator(OPERATOR2));
+        assertFalse(aori.isOperator(NON_OWNER));
+    }
+}

--- a/test/foundry/39_OperatorTests.t.sol
+++ b/test/foundry/39_OperatorTests.t.sol
@@ -23,7 +23,6 @@ contract OperatorTests is TestUtils {
 
     function testAddOperator_Success() public {
         assertFalse(localAori.isOperator(OPERATOR));
-        vm.prank(address(this));
         vm.expectEmit(true, false, false, false);
         emit OperatorAdded(OPERATOR);
         localAori.addOperator(OPERATOR);
@@ -38,7 +37,6 @@ contract OperatorTests is TestUtils {
     }
 
     function testAddOperator_OperatorCannotAddOperator() public {
-        vm.prank(address(this));
         localAori.addOperator(OPERATOR);
 
         vm.prank(OPERATOR);
@@ -47,11 +45,9 @@ contract OperatorTests is TestUtils {
     }
 
     function testRemoveOperator_Success() public {
-        vm.prank(address(this));
         localAori.addOperator(OPERATOR);
         assertTrue(localAori.isOperator(OPERATOR));
 
-        vm.prank(address(this));
         vm.expectEmit(true, false, false, false);
         emit OperatorRemoved(OPERATOR);
         localAori.removeOperator(OPERATOR);
@@ -59,7 +55,6 @@ contract OperatorTests is TestUtils {
     }
 
     function testRemoveOperator_OnlyOwner() public {
-        vm.prank(address(this));
         localAori.addOperator(OPERATOR);
 
         vm.prank(NON_OWNER);
@@ -69,7 +64,6 @@ contract OperatorTests is TestUtils {
     }
 
     function testRemoveOperator_OperatorCannotRemoveSelf() public {
-        vm.prank(address(this));
         localAori.addOperator(OPERATOR);
 
         vm.prank(OPERATOR);
@@ -79,15 +73,12 @@ contract OperatorTests is TestUtils {
     }
 
     function testMultipleOperators() public {
-        vm.startPrank(address(this));
         localAori.addOperator(OPERATOR);
         localAori.addOperator(OPERATOR2);
-        vm.stopPrank();
 
         assertTrue(localAori.isOperator(OPERATOR));
         assertTrue(localAori.isOperator(OPERATOR2));
 
-        vm.prank(address(this));
         localAori.removeOperator(OPERATOR);
 
         assertFalse(localAori.isOperator(OPERATOR));
@@ -99,7 +90,6 @@ contract OperatorTests is TestUtils {
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
     function testOperator_AddAllowedSolver() public {
-        vm.prank(address(this));
         localAori.addOperator(OPERATOR);
 
         vm.prank(OPERATOR);
@@ -108,10 +98,8 @@ contract OperatorTests is TestUtils {
     }
 
     function testOperator_RemoveAllowedSolver() public {
-        vm.startPrank(address(this));
         localAori.addOperator(OPERATOR);
         localAori.addAllowedSolver(TEST_SOLVER);
-        vm.stopPrank();
 
         vm.prank(OPERATOR);
         localAori.removeAllowedSolver(TEST_SOLVER);
@@ -119,7 +107,6 @@ contract OperatorTests is TestUtils {
     }
 
     function testOperator_AddAllowedHook() public {
-        vm.prank(address(this));
         localAori.addOperator(OPERATOR);
 
         vm.prank(OPERATOR);
@@ -128,10 +115,8 @@ contract OperatorTests is TestUtils {
     }
 
     function testOperator_RemoveAllowedHook() public {
-        vm.startPrank(address(this));
         localAori.addOperator(OPERATOR);
         localAori.addAllowedHook(TEST_HOOK);
-        vm.stopPrank();
 
         vm.prank(OPERATOR);
         localAori.removeAllowedHook(TEST_HOOK);
@@ -139,7 +124,6 @@ contract OperatorTests is TestUtils {
     }
 
     function testOperator_AddSupportedChain() public {
-        vm.prank(address(this));
         localAori.addOperator(OPERATOR);
 
         vm.prank(OPERATOR);
@@ -148,10 +132,8 @@ contract OperatorTests is TestUtils {
     }
 
     function testOperator_RemoveSupportedChain() public {
-        vm.startPrank(address(this));
         localAori.addOperator(OPERATOR);
         localAori.addSupportedChain(TEST_EID);
-        vm.stopPrank();
 
         vm.prank(OPERATOR);
         localAori.removeSupportedChain(TEST_EID);
@@ -159,7 +141,6 @@ contract OperatorTests is TestUtils {
     }
 
     function testOperator_SetPeer() public {
-        vm.prank(address(this));
         localAori.addOperator(OPERATOR);
 
         bytes32 peer = bytes32(uint256(uint160(address(0xBEEF))));
@@ -168,7 +149,6 @@ contract OperatorTests is TestUtils {
     }
 
     function testOperator_SetMaxFillsPerSettle() public {
-        vm.prank(address(this));
         localAori.addOperator(OPERATOR);
 
         vm.prank(OPERATOR);
@@ -176,7 +156,6 @@ contract OperatorTests is TestUtils {
     }
 
     function testOperator_SetProtocolFee() public {
-        vm.prank(address(this));
         localAori.addOperator(OPERATOR);
 
         vm.prank(OPERATOR);
@@ -184,7 +163,6 @@ contract OperatorTests is TestUtils {
     }
 
     function testOperator_SetProtocolTreasury() public {
-        vm.prank(address(this));
         localAori.addOperator(OPERATOR);
 
         vm.prank(OPERATOR);
@@ -192,7 +170,6 @@ contract OperatorTests is TestUtils {
     }
 
     function testOperator_SetMaxFee() public {
-        vm.prank(address(this));
         localAori.addOperator(OPERATOR);
 
         vm.prank(OPERATOR);
@@ -204,7 +181,6 @@ contract OperatorTests is TestUtils {
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
     function testOperator_CannotPause() public {
-        vm.prank(address(this));
         localAori.addOperator(OPERATOR);
 
         vm.prank(OPERATOR);
@@ -213,10 +189,7 @@ contract OperatorTests is TestUtils {
     }
 
     function testOperator_CannotUnpause() public {
-        vm.prank(address(this));
         localAori.pause();
-
-        vm.prank(address(this));
         localAori.addOperator(OPERATOR);
 
         vm.prank(OPERATOR);
@@ -225,7 +198,6 @@ contract OperatorTests is TestUtils {
     }
 
     function testOperator_CannotEmergencyCancel() public {
-        vm.prank(address(this));
         localAori.addOperator(OPERATOR);
 
         vm.prank(OPERATOR);
@@ -234,7 +206,6 @@ contract OperatorTests is TestUtils {
     }
 
     function testOperator_CannotEmergencyWithdraw() public {
-        vm.prank(address(this));
         localAori.addOperator(OPERATOR);
 
         vm.prank(OPERATOR);
@@ -243,7 +214,6 @@ contract OperatorTests is TestUtils {
     }
 
     function testOperator_CannotEmergencyWithdrawFromBalance() public {
-        vm.prank(address(this));
         localAori.addOperator(OPERATOR);
 
         vm.prank(OPERATOR);
@@ -252,7 +222,6 @@ contract OperatorTests is TestUtils {
     }
 
     function testOperator_CannotTransferOwnership() public {
-        vm.prank(address(this));
         localAori.addOperator(OPERATOR);
 
         vm.prank(OPERATOR);
@@ -308,7 +277,6 @@ contract OperatorTests is TestUtils {
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
     function testOwner_CanStillCallOperationalFunctions() public {
-        vm.startPrank(address(this));
         localAori.addAllowedSolver(TEST_SOLVER);
         assertTrue(localAori.isAllowedSolver(TEST_SOLVER));
 
@@ -322,8 +290,6 @@ contract OperatorTests is TestUtils {
         localAori.setProtocolFee(50);
         localAori.setProtocolTreasury(address(0xBEEF));
         localAori.setMaxFee(500);
-
-        vm.stopPrank();
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -331,9 +297,7 @@ contract OperatorTests is TestUtils {
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
     function testRevokedOperator_LosesAccess() public {
-        vm.startPrank(address(this));
         localAori.addOperator(OPERATOR);
-        vm.stopPrank();
 
         // Operator can call
         vm.prank(OPERATOR);
@@ -341,7 +305,6 @@ contract OperatorTests is TestUtils {
         assertTrue(localAori.isAllowedSolver(TEST_SOLVER));
 
         // Revoke operator
-        vm.prank(address(this));
         localAori.removeOperator(OPERATOR);
 
         // Operator can no longer call

--- a/test/foundry/TestUtils.sol
+++ b/test/foundry/TestUtils.sol
@@ -65,7 +65,7 @@ contract TestUtils is TestHelperOz5 {
      */
     function deployWithProxy(address implementation, address owner, uint16 maxFillsPerSettle) public returns (address) {
         ERC1967Proxy proxy = new ERC1967Proxy(
-            implementation, abi.encodeCall(Aori.initialize, (owner, maxFillsPerSettle, new address[](0), new address[](0), new uint32[](0)))
+            implementation, abi.encodeCall(Aori.initialize, (owner, maxFillsPerSettle, new address[](0), new address[](0), new uint32[](0), new address[](0)))
         );
         return address(proxy);
     }


### PR DESCRIPTION
  ## Summary

  - Adds an operator role so daily operational functions (solver/hook/chain/peer management, fee config) 
  - Critical functions (pause, emergency, upgrade) remain owner-only
  - 11 admin functions now use `onlyOwnerOrOperator`; 11 remain `onlyOwner`

  ## Design

  - `mapping(address => bool) isOperator` appended to `AoriStorageData` (offset 12)
  - `onlyOwnerOrOperator` modifier backed by `_checkOwnerOrOperator()` internal function to minimize bytecode duplication
  - `setPeer` overridden (replicates parent body to avoid `super.setPeer()` triggering OApp's `onlyOwner`)
  - `setDelegate` stays owner-only — not `virtual` in OAppCoreUpgradeable
  - `initialize` accepts `_initialOperators` array for fresh deploys
  - AoriLens updated with `isOperator` view at storage offset 12
  - Bytecode: 24,328 bytes (248 byte margin)

  ## Access Control

  ### Owner only

  | Function | Purpose |
  |----------|---------|
  | `pause()` | Emergency pause |
  | `unpause()` | Resume operations |
  | `emergencyCancel(orderId, recipient)` | Force cancel active orders |
  | `emergencyWithdraw(token, amount, recipient)` | Extract stuck tokens |
  | `emergencyWithdrawFromBalance(token, amount, user, isLocked, recipient)` | Extract stuck user tokens |
  | `addOperator(operator)` | Grant operator role |
  | `removeOperator(operator)` | Revoke operator role |
  | `setDelegate(delegate)` | Set LZ delegate (not `virtual`, can't override) |
  | `upgradeToAndCall(newImpl, data)` | UUPS upgrade |
  | `transferOwnership(newOwner)` | Transfer ownership |
  | `renounceOwnership()` | Renounce ownership |

  ### Owner or Operator

  | Function | Purpose |
  |----------|---------|
  | `addAllowedSolver(solver)` | Whitelist solver |
  | `removeAllowedSolver(solver)` | Remove solver |
  | `addAllowedHook(hook)` | Whitelist hook |
  | `removeAllowedHook(hook)` | Remove hook |
  | `addSupportedChain(eid)` | Add chain |
  | `removeSupportedChain(eid)` | Remove chain |
  | `setPeer(eid, peer)` | Set LZ peer |
  | `setMaxFillsPerSettle(maxFills)` | Update batch limit |
  | `setProtocolFee(feeMbps)` | Set protocol fee |
  | `setProtocolTreasury(treasury)` | Set fee recipient |
  | `setMaxFee(maxFeeMbps)` | Set max additional fee |