### PR TITLE
fix: correct AoriLens IS_OPERATOR_OFFSET from 12 to 11

### DIFF
--- a/contracts/AoriLens.sol
+++ b/contracts/AoriLens.sol
@@ -56,7 +56,7 @@ contract AoriLens {
     uint256 constant IS_ALLOWED_HOOK_OFFSET = 5;
     uint256 constant IS_ALLOWED_SOLVER_OFFSET = 6;
     uint256 constant SRC_EID_TO_FILLER_FILLS_OFFSET = 7;
-    uint256 constant IS_OPERATOR_OFFSET = 12;
+    uint256 constant IS_OPERATOR_OFFSET = 11;
 
     IAoriLensTarget public immutable aori;
 

--- a/test/foundry/39_OperatorTests.t.sol
+++ b/test/foundry/39_OperatorTests.t.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.34;
 
 import "forge-std/Test.sol";
 import "../../contracts/Aori.sol";
+import "../../contracts/AoriLens.sol";
 import "../../contracts/interfaces/IAori.sol";
 import "./TestUtils.sol";
 
@@ -337,5 +338,35 @@ contract OperatorTests is TestUtils {
         assertTrue(aori.isOperator(OPERATOR));
         assertTrue(aori.isOperator(OPERATOR2));
         assertFalse(aori.isOperator(NON_OWNER));
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*              AORILENS OPERATOR VIEW INTEGRATION              */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    function testLens_IsOperator_ReturnsTrue() public {
+        localAori.addOperator(OPERATOR);
+        assertTrue(localLens.isOperator(OPERATOR));
+    }
+
+    function testLens_IsOperator_ReturnsFalse() public {
+        assertFalse(localLens.isOperator(OPERATOR));
+    }
+
+    function testLens_IsOperator_AfterRemoval() public {
+        localAori.addOperator(OPERATOR);
+        assertTrue(localLens.isOperator(OPERATOR));
+
+        localAori.removeOperator(OPERATOR);
+        assertFalse(localLens.isOperator(OPERATOR));
+    }
+
+    function testLens_IsOperator_MatchesAoriDirect() public {
+        localAori.addOperator(OPERATOR);
+        localAori.addOperator(OPERATOR2);
+
+        assertEq(localLens.isOperator(OPERATOR), localAori.isOperator(OPERATOR));
+        assertEq(localLens.isOperator(OPERATOR2), localAori.isOperator(OPERATOR2));
+        assertEq(localLens.isOperator(NON_OWNER), localAori.isOperator(NON_OWNER));
     }
 }


### PR DESCRIPTION
## Summary

- Fixes `IS_OPERATOR_OFFSET` in `AoriLens.sol` from 12 to 11
- `protocolFeeMbps` (uint16) and `protocolTreasury` (address) pack into a single storage slot (22 bytes < 32), so `isOperator` is at offset 11, not 12
- With offset 12, `AoriLens.isOperator()` always returned `false` for every address
- Adds 4 AoriLens integration tests to prevent regression

## Storage Layout (offsets 8+)

| Slot | Fields |
|------|--------|
| 8 | `protocolFeeMbps` (uint16, 2B) + `protocolTreasury` (address, 20B) — **packed** |
| 9 | `pendingProtocolFees` (mapping) |
| 10 | `maxFeeMbps` (uint16) |
| **11** | `isOperator` (mapping) |

## Test plan

- [x] `testLens_IsOperator_ReturnsTrue` — operator set via Aori reads true via AoriLens
- [x] `testLens_IsOperator_ReturnsFalse` — non-operator reads false
- [x] `testLens_IsOperator_AfterRemoval` — removed operator reads false
- [x] `testLens_IsOperator_MatchesAoriDirect` — AoriLens matches Aori for multiple addresses
- [x] Full suite: 604 tests passing