### PR TITLE
refactor: move view wrappers from Aori to AoriLens

### DIFF
--- a/contracts/Aori.sol
+++ b/contracts/Aori.sol
@@ -252,23 +252,11 @@ contract Aori is IAori, AoriStorage, OAppUpgradeable, PausableUpgradeable, UUPSU
     /// @notice Sets the protocol treasury address that receives protocol fees
     function setProtocolTreasury(address treasury) external onlyOwnerOrOperator { AoriAdminLib.setProtocolTreasury(treasury); }
 
-    /// @notice Returns the current protocol fee and treasury address
-    function getProtocolConfig() external view returns (uint16 feeMbps, address treasury) { return AoriAdminLib.getProtocolConfig(); }
-
-    /// @notice Returns the accumulated unclaimed protocol fees for a given token
-    function getPendingProtocolFees(address token) external view returns (uint256) { return AoriAdminLib.getPendingProtocolFees(token); }
-
     /// @notice Sets the maximum allowed additional fee in millibasis points (cross-validated with protocolFeeMbps)
     function setMaxFee(uint16 maxFeeMbps) external onlyOwnerOrOperator { AoriAdminLib.setMaxFee(maxFeeMbps); }
 
-    /// @notice Returns the current maximum allowed additional fee
-    function getMaxFee() external view returns (uint16) { return AoriAdminLib.getMaxFee(); }
-
     /// @notice Sets the maximum number of fills processed per settlement batch
     function setMaxFillsPerSettle(uint16 maxFills) external onlyOwnerOrOperator { AoriAdminLib.setMaxFillsPerSettle(maxFills); }
-
-    /// @notice Returns the current maximum fills per settlement batch
-    function getMaxFillsPerSettle() external view returns (uint16) { return AoriAdminLib.getMaxFillsPerSettle(); }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                         MODIFIERS                          */

--- a/contracts/AoriLens.sol
+++ b/contracts/AoriLens.sol
@@ -56,6 +56,9 @@ contract AoriLens {
     uint256 constant IS_ALLOWED_HOOK_OFFSET = 5;
     uint256 constant IS_ALLOWED_SOLVER_OFFSET = 6;
     uint256 constant SRC_EID_TO_FILLER_FILLS_OFFSET = 7;
+    uint256 constant PROTOCOL_FEE_OFFSET = 8; // protocolFeeMbps (uint16) + protocolTreasury (address) packed
+    uint256 constant PENDING_PROTOCOL_FEES_OFFSET = 9;
+    uint256 constant MAX_FEE_MBPS_OFFSET = 10;
     uint256 constant IS_OPERATOR_OFFSET = 11;
 
     IAoriLensTarget public immutable aori;
@@ -203,6 +206,40 @@ contract AoriLens {
                 orderHashesPerEid[j][i] = aori.readStorage(elementSlot);
             }
         }
+    }
+
+    /**
+     * @notice Returns the current protocol fee and treasury address
+     */
+    function getProtocolConfig() external view returns (uint16 feeMbps, address treasury) {
+        bytes32 slot = bytes32(uint256(AORI_STORAGE_SLOT) + PROTOCOL_FEE_OFFSET);
+        bytes32 value = aori.readStorage(slot);
+        feeMbps = uint16(uint256(value));
+        treasury = address(uint160(uint256(value) >> 16));
+    }
+
+    /**
+     * @notice Returns the accumulated unclaimed protocol fees for a given token
+     */
+    function getPendingProtocolFees(address token) external view returns (uint256) {
+        bytes32 slot = keccak256(abi.encode(token, uint256(AORI_STORAGE_SLOT) + PENDING_PROTOCOL_FEES_OFFSET));
+        return uint256(aori.readStorage(slot));
+    }
+
+    /**
+     * @notice Returns the current maximum allowed additional fee
+     */
+    function getMaxFee() external view returns (uint16) {
+        bytes32 slot = bytes32(uint256(AORI_STORAGE_SLOT) + MAX_FEE_MBPS_OFFSET);
+        return uint16(uint256(aori.readStorage(slot)));
+    }
+
+    /**
+     * @notice Returns the current maximum fills per settlement batch
+     */
+    function getMaxFillsPerSettle() external view returns (uint16) {
+        bytes32 slot = bytes32(uint256(AORI_STORAGE_SLOT) + MAX_FILLS_PER_SETTLE_OFFSET);
+        return uint16(uint256(aori.readStorage(slot)));
     }
 
     /**

--- a/contracts/interfaces/IAori.sol
+++ b/contracts/interfaces/IAori.sol
@@ -221,14 +221,6 @@ interface IAori {
 
     function readStorageArray(bytes32 slot) external view returns (uint256 length);
 
-    function getProtocolConfig() external view returns (uint16 feeMbps, address treasury);
-
-    function getPendingProtocolFees(address token) external view returns (uint256 amount);
-
-    function getMaxFee() external view returns (uint16 maxFeeMbps);
-
-    function getMaxFillsPerSettle() external view returns (uint16);
-
     function isOperator(address addr) external view returns (bool);
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/

--- a/test/foundry/39_OperatorTests.t.sol
+++ b/test/foundry/39_OperatorTests.t.sol
@@ -369,4 +369,45 @@ contract OperatorTests is TestUtils {
         assertEq(localLens.isOperator(OPERATOR2), localAori.isOperator(OPERATOR2));
         assertEq(localLens.isOperator(NON_OWNER), localAori.isOperator(NON_OWNER));
     }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*          AORILENS PROTOCOL CONFIG VIEW INTEGRATION              */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    function testLens_GetProtocolConfig_Default() public view {
+        (uint16 feeMbps, address treasury) = localLens.getProtocolConfig();
+        assertEq(feeMbps, 0, "Default protocol fee should be 0");
+        assertEq(treasury, address(this), "Default treasury should be owner");
+    }
+
+    function testLens_GetProtocolConfig_AfterUpdate() public {
+        localAori.setProtocolFee(500); // 0.5%
+        localAori.setProtocolTreasury(OPERATOR);
+
+        (uint16 feeMbps, address treasury) = localLens.getProtocolConfig();
+        assertEq(feeMbps, 500, "Protocol fee should be 500");
+        assertEq(treasury, OPERATOR, "Treasury should be updated");
+    }
+
+    function testLens_GetMaxFee_Default() public view {
+        assertEq(localLens.getMaxFee(), 1000, "Default max fee should be 1000");
+    }
+
+    function testLens_GetMaxFee_AfterUpdate() public {
+        localAori.setMaxFee(2000);
+        assertEq(localLens.getMaxFee(), 2000, "Max fee should be updated");
+    }
+
+    function testLens_GetMaxFillsPerSettle_Default() public view {
+        assertEq(localLens.getMaxFillsPerSettle(), MAX_FILLS_PER_SETTLE, "Should match init value");
+    }
+
+    function testLens_GetMaxFillsPerSettle_AfterUpdate() public {
+        localAori.setMaxFillsPerSettle(20);
+        assertEq(localLens.getMaxFillsPerSettle(), 20, "Max fills should be updated");
+    }
+
+    function testLens_GetPendingProtocolFees_Default() public view {
+        assertEq(localLens.getPendingProtocolFees(address(0x1)), 0, "Default pending fees should be 0");
+    }
 }


### PR DESCRIPTION
## Summary
- Move `getProtocolConfig`, `getPendingProtocolFees`, `getMaxFee`, and `getMaxFillsPerSettle` from Aori.sol to AoriLens.sol
- These are read-only functions not called internally — AoriLens reads the storage slots directly
- Saves ~644 bytes on Aori bytecode (24,690 → 24,046), restoring 530 bytes of margin under the 24,576 EIP-170 limit
- Required to keep Aori deployable after the hook value-forwarding changes in PR #75

## Test plan
- [x] All 606 tests pass
- [x] Aori contract size: 24,046 bytes (530 byte margin)