### PR TITLE
add github actions workflow so forge tests run on prs and pushes

### DIFF
--- a/.github/workflows/forge.yml
+++ b/.github/workflows/forge.yml
@@ -1,0 +1,37 @@
+name: forge tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+concurrency:
+  group: forge-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.6.5
+
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: install js dependencies
+        run: pnpm install
+
+      - name: run forge tests
+        run: forge test


### PR DESCRIPTION
## what this does

- adds a GitHub Actions workflow that installs Foundry, pnpm, Node 20, runs `pnpm install`, then `forge test`
- runs on pushes to `master` and on every pull request
- uses concurrency so newer runs cancel stale ones on the same branch/pr

## why

there was no `.github` automation in the repo, so regressions only showed up if someone ran tests locally. CI gives every contributor the same signal before merge.

---

made by mooncitydev