### PR TITLE
fix: emergency withdraw should not drain native when rescuing erc20

### DIFF
--- a/contracts/Aori.sol
+++ b/contracts/Aori.sol
@@ -237,16 +237,21 @@ contract Aori is IAori, OApp, ReentrancyGuard, Pausable, EIP712 {
     /**
      * @notice Emergency function to extract tokens or ether from the contract
      * @dev Only callable by the contract owner. Does not update user balances - use for direct contract withdrawals.
-     * @param token The token address to withdraw
-     * @param amount The amount of tokens to withdraw
+     * Use `NATIVE_TOKEN` as `token` to withdraw native currency; use an ERC20 address to withdraw that token only.
+     * Previously this always sent the entire contract ETH balance before any ERC20 transfer, so rescuing ERC20 could unintentionally drain all ETH.
+     * @param token The token address to withdraw (`NATIVE_TOKEN` for native)
+     * @param amount For ERC20, amount to transfer (must be > 0). For native, amount to send; 0 means the full contract balance (same idea as `withdraw`).
      */
     function emergencyWithdraw(address token, uint256 amount) external onlyOwner {
-        uint256 etherBalance = address(this).balance;
-        if (etherBalance > 0) {
-            (bool success, ) = payable(owner()).call{ value: etherBalance }("");
+        if (token.isNativeToken()) {
+            uint256 etherBalance = address(this).balance;
+            uint256 withdrawAmount = amount == 0 ? etherBalance : amount;
+            require(withdrawAmount > 0, "Amount must be greater than zero");
+            require(etherBalance >= withdrawAmount, "Insufficient contract native balance");
+            (bool success, ) = payable(owner()).call{ value: withdrawAmount }("");
             require(success, "Ether withdrawal failed");
-        }
-        if (amount > 0) {
+        } else {
+            require(amount > 0, "Amount must be greater than zero");
             token.safeTransfer(owner(), amount);
         }
     }

--- a/test/foundry/12_PausedTests.t.sol
+++ b/test/foundry/12_PausedTests.t.sol
@@ -20,6 +20,7 @@ pragma solidity 0.8.28;
  */
 import {IAori} from "../../contracts/IAori.sol";
 import {OptionsBuilder} from "@layerzerolabs/oapp-evm/contracts/oapp/libs/OptionsBuilder.sol";
+import {NATIVE_TOKEN} from "../../contracts/AoriUtils.sol";
 import "./TestUtils.sol";
 
 /**
@@ -203,8 +204,8 @@ contract PausedTests is TestUtils {
         // Get balance before emergency withdrawal
         uint256 adminBalanceBefore = address(admin).balance;
 
-        // Execute emergency withdrawal (amount is ignored for ETH)
-        localAori.emergencyWithdraw(address(0), 0);
+        // Native: amount 0 withdraws full contract balance
+        localAori.emergencyWithdraw(NATIVE_TOKEN, 0);
 
         // Check balance after emergency withdrawal
         uint256 adminBalanceAfter = address(admin).balance;

--- a/test/foundry/32_EmergencyTests.t.sol
+++ b/test/foundry/32_EmergencyTests.t.sol
@@ -53,6 +53,7 @@ pragma solidity 0.8.28;
  */
 import {IAori} from "../../contracts/IAori.sol";
 import {Aori} from "../../contracts/Aori.sol";
+import {NATIVE_TOKEN} from "../../contracts/AoriUtils.sol";
 import "./TestUtils.sol";
 
 contract EmergencyTests is TestUtils {
@@ -287,7 +288,7 @@ contract EmergencyTests is TestUtils {
 
         uint256 ownerBalanceBefore = address(this).balance;
         
-        localAori.emergencyWithdraw(address(0), 0);
+        localAori.emergencyWithdraw(NATIVE_TOKEN, 0);
 
         assertEq(
             address(this).balance, 
@@ -307,10 +308,19 @@ contract EmergencyTests is TestUtils {
         uint256 ownerEthBefore = address(this).balance;
         uint256 ownerTokenBefore = inputToken.balanceOf(address(this));
 
-        localAori.emergencyWithdraw(address(inputToken), 0);
+        localAori.emergencyWithdraw(NATIVE_TOKEN, 0);
 
         assertEq(address(this).balance, ownerEthBefore + ethAmount, "Should receive ETH");
         assertEq(inputToken.balanceOf(address(this)), ownerTokenBefore, "Token balance unchanged");
+    }
+
+    /**
+     * @notice ERC20 path with zero amount reverts; use NATIVE_TOKEN to move ETH
+     */
+    function testEmergencyWithdrawErc20ZeroAmountReverts() public {
+        vm.deal(address(localAori), 0.5 ether);
+        vm.expectRevert("Amount must be greater than zero");
+        localAori.emergencyWithdraw(address(inputToken), 0);
     }
 
     /**
@@ -353,6 +363,7 @@ contract EmergencyTests is TestUtils {
         uint256 ownerEthBefore = address(this).balance;
         uint256 ownerTokenBefore = inputToken.balanceOf(address(this));
 
+        localAori.emergencyWithdraw(NATIVE_TOKEN, ethAmount);
         localAori.emergencyWithdraw(address(inputToken), tokenAmount);
 
         assertEq(address(this).balance, ownerEthBefore + ethAmount, "Should receive ETH");
@@ -363,15 +374,8 @@ contract EmergencyTests is TestUtils {
      * @notice Tests emergency withdraw with no ETH and no tokens
      */
     function testEmergencyWithdrawNoETHNoTokens() public {
-        uint256 ownerEthBefore = address(this).balance;
-        uint256 ownerTokenBefore = inputToken.balanceOf(address(this));
-
-        // Call with zero amount and no ETH in contract
+        vm.expectRevert("Amount must be greater than zero");
         localAori.emergencyWithdraw(address(inputToken), 0);
-
-        // Balances should remain unchanged
-        assertEq(address(this).balance, ownerEthBefore, "ETH balance should be unchanged");
-        assertEq(inputToken.balanceOf(address(this)), ownerTokenBefore, "Token balance should be unchanged");
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/


### PR DESCRIPTION
## summary
The two-argument emergencyWithdraw previously sent the full contract ETH balance on every call whenever the contract held ETH, then optionally transferred an ERC20. That made ERC20-only recovery accidentally sweep all native balance.

## changes
- Native moves only when token is NATIVE_TOKEN; amount 0 means full native balance (same convenience as withdraw).
- ERC20 path transfers only that token and does not touch unrelated ETH.
- Tests updated to use NATIVE_TOKEN instead of address(0); split combined ETH+token test into two calls; expect revert for ERC20 with zero amount.

## contributor
made by mooncitydev

## testing
forge was not available on PATH in this environment; please run forge test locally before merge.
