### PR TITLE
fix: validate filler is whitelisted solver on settlement receive

### DIFF
--- a/contracts/lib/AoriSettleLib.sol
+++ b/contracts/lib/AoriSettleLib.sol
@@ -127,6 +127,12 @@ library AoriSettleLib {
             return; // Skip non-active orders
         }
 
+        // Validate filler matches order's srcSolver constraint (compromised-peer mitigation)
+        if (order.options.srcSolver != address(0) && filler != order.options.srcSolver) {
+            emit IAori.SettleFailed(orderId);
+            return;
+        }
+
         (uint128 protocolFee, uint128 additionalFee, uint128 fillerAmount) =
             ValidationUtils.calculateFees(order.inputAmount, $.protocolFeeMbps, order.options.feeMbps);
 

--- a/contracts/lib/AoriSettleLib.sol
+++ b/contracts/lib/AoriSettleLib.sol
@@ -127,8 +127,8 @@ library AoriSettleLib {
             return; // Skip non-active orders
         }
 
-        // Validate filler matches order's srcSolver constraint (compromised-peer mitigation)
-        if (order.options.srcSolver != address(0) && filler != order.options.srcSolver) {
+        // Validate filler is a whitelisted solver (compromised-peer mitigation)
+        if (!$.isAllowedSolver[filler]) {
             emit IAori.SettleFailed(orderId);
             return;
         }

--- a/test/foundry/7_SettlementTests.t.sol
+++ b/test/foundry/7_SettlementTests.t.sol
@@ -494,42 +494,34 @@ contract SettlementTests is TestUtils {
     }
 
     /**
-     * @notice Test that settlement rejects a filler that doesn't match order.options.srcSolver
+     * @notice Test that settlement rejects a non-whitelisted filler address
      * @dev Simulates a compromised peer sending a forged settlement with an attacker address as filler.
-     *      When srcSolver is set, only that address should receive settled funds.
      */
-    function testSettleRejectsMismatchedSrcSolver() public {
-        // Create an order with a specific srcSolver set to the legitimate solver
+    function testSettleRejectsNonWhitelistedFiller() public {
         Order memory order = createValidOrder();
-        order.options.srcSolver = solver;
-
         bytes memory signature = signOrderWithContract(order, userAPrivKey, address(testLocalAori));
         bytes32 orderId = keccak256(abi.encode(order));
 
-        // Deposit the order
         vm.prank(userA);
         inputToken.approve(address(testLocalAori), order.inputAmount);
 
         vm.prank(solver);
         testLocalAori.deposit(order, signature);
 
-        // Verify order is active
         assertEq(uint8(testLocalAori.orderStatus(orderId)), uint8(OrderStatus.Active));
 
-        // Simulate a compromised peer sending a forged settlement with an attacker as filler
+        // Simulate a compromised peer sending a forged settlement with a non-whitelisted attacker
         address attacker = address(0xDEAD);
         bytes memory forgedPayload = abi.encodePacked(
             uint8(0),       // settlement message type
-            attacker,       // attacker's address as filler
+            attacker,       // attacker's address as filler (not whitelisted)
             uint16(1),      // fill count
             orderId         // legitimate order
         );
 
-        // Record balances before
         uint256 attackerBalanceBefore = testLocalLens.getUnlockedBalances(attacker, address(inputToken));
         uint256 offererLockedBefore = testLocalLens.getLockedBalances(userA, address(inputToken));
 
-        // Deliver the forged settlement via lzReceive
         vm.chainId(localEid);
         vm.prank(address(endpoints[localEid]));
         testLocalAori.lzReceive(
@@ -541,30 +533,19 @@ contract SettlementTests is TestUtils {
         );
 
         // Attacker should NOT have received any funds
-        uint256 attackerBalanceAfter = testLocalLens.getUnlockedBalances(attacker, address(inputToken));
-        assertEq(attackerBalanceBefore, attackerBalanceAfter, "Attacker should not receive funds when srcSolver is set");
-
-        // Offerer's locked balance should be unchanged (order not settled)
-        uint256 offererLockedAfter = testLocalLens.getLockedBalances(userA, address(inputToken));
-        assertEq(offererLockedBefore, offererLockedAfter, "Offerer locked balance should be unchanged");
-
-        // Order should still be Active, not Settled
+        assertEq(testLocalLens.getUnlockedBalances(attacker, address(inputToken)), attackerBalanceBefore, "Non-whitelisted filler should not receive funds");
+        assertEq(testLocalLens.getLockedBalances(userA, address(inputToken)), offererLockedBefore, "Offerer locked balance should be unchanged");
         assertEq(uint8(testLocalAori.orderStatus(orderId)), uint8(OrderStatus.Active), "Order should remain Active");
     }
 
     /**
-     * @notice Test that settlement succeeds when filler matches srcSolver
-     * @dev Ensures the srcSolver validation doesn't break legitimate settlements
+     * @notice Test that settlement succeeds when filler is a whitelisted solver
      */
-    function testSettleSucceedsWithMatchingSrcSolver() public {
-        // Create an order with srcSolver set to the legitimate solver
+    function testSettleSucceedsWithWhitelistedFiller() public {
         Order memory order = createValidOrder();
-        order.options.srcSolver = solver;
-
         bytes memory signature = signOrderWithContract(order, userAPrivKey, address(testLocalAori));
         bytes32 orderId = keccak256(abi.encode(order));
 
-        // Deposit the order
         vm.prank(userA);
         inputToken.approve(address(testLocalAori), order.inputAmount);
 
@@ -573,12 +554,12 @@ contract SettlementTests is TestUtils {
 
         assertEq(uint8(testLocalAori.orderStatus(orderId)), uint8(OrderStatus.Active));
 
-        // Send legitimate settlement with solver as filler (matches srcSolver)
-        bytes memory legitimatePayload = abi.encodePacked(
+        // Settle with the whitelisted solver as filler
+        bytes memory payload = abi.encodePacked(
             uint8(0),       // settlement message type
-            solver,         // legitimate solver as filler
+            solver,         // whitelisted solver as filler
             uint16(1),      // fill count
-            orderId         // order
+            orderId
         );
 
         vm.chainId(localEid);
@@ -586,31 +567,23 @@ contract SettlementTests is TestUtils {
         testLocalAori.lzReceive(
             Origin(remoteEid, bytes32(uint256(uint160(address(testRemoteAori)))), 1),
             keccak256("legit-guid"),
-            legitimatePayload,
+            payload,
             address(0),
             bytes("")
         );
 
-        // Order should be settled
         assertEq(uint8(testLocalAori.orderStatus(orderId)), uint8(OrderStatus.Settled), "Order should be settled");
-
-        // Solver should have received unlocked balance
-        uint256 solverBalance = testLocalLens.getUnlockedBalances(solver, address(inputToken));
-        assertGt(solverBalance, 0, "Solver should have received funds");
+        assertGt(testLocalLens.getUnlockedBalances(solver, address(inputToken)), 0, "Whitelisted solver should have received funds");
     }
 
     /**
-     * @notice Test that settlement with srcSolver=address(0) allows any filler (backwards compatible)
+     * @notice Test that a removed solver can no longer receive settlement funds
      */
-    function testSettleAllowsAnyFillerWhenSrcSolverUnset() public {
-        // Create order with default options (srcSolver = address(0))
+    function testSettleRejectsRemovedSolver() public {
         Order memory order = createValidOrder();
-        // srcSolver is already address(0) from defaultOrderOptions()
-
         bytes memory signature = signOrderWithContract(order, userAPrivKey, address(testLocalAori));
         bytes32 orderId = keccak256(abi.encode(order));
 
-        // Deposit
         vm.prank(userA);
         inputToken.approve(address(testLocalAori), order.inputAmount);
 
@@ -619,11 +592,13 @@ contract SettlementTests is TestUtils {
 
         assertEq(uint8(testLocalAori.orderStatus(orderId)), uint8(OrderStatus.Active));
 
-        // Settle with a different address as filler — should succeed when srcSolver is unset
-        address anotherSolver = address(0xBEEF);
+        // Remove the solver from whitelist after deposit
+        testLocalAori.removeAllowedSolver(solver);
+
+        // Try to settle with the now-removed solver
         bytes memory payload = abi.encodePacked(
             uint8(0),
-            anotherSolver,
+            solver,         // was whitelisted, now removed
             uint16(1),
             orderId
         );
@@ -632,17 +607,14 @@ contract SettlementTests is TestUtils {
         vm.prank(address(endpoints[localEid]));
         testLocalAori.lzReceive(
             Origin(remoteEid, bytes32(uint256(uint160(address(testRemoteAori)))), 1),
-            keccak256("any-filler-guid"),
+            keccak256("removed-solver-guid"),
             payload,
             address(0),
             bytes("")
         );
 
-        // Order should be settled (srcSolver=0 means any filler allowed)
-        assertEq(uint8(testLocalAori.orderStatus(orderId)), uint8(OrderStatus.Settled), "Order should be settled with any filler");
-
-        // The other solver should have received funds
-        uint256 otherSolverBalance = testLocalLens.getUnlockedBalances(anotherSolver, address(inputToken));
-        assertGt(otherSolverBalance, 0, "Any filler should receive funds when srcSolver is unset");
+        // Settlement should fail — solver is no longer whitelisted
+        assertEq(uint8(testLocalAori.orderStatus(orderId)), uint8(OrderStatus.Active), "Order should remain Active for removed solver");
+        assertEq(testLocalLens.getUnlockedBalances(solver, address(inputToken)), 0, "Removed solver should not receive funds");
     }
 }

--- a/test/foundry/7_SettlementTests.t.sol
+++ b/test/foundry/7_SettlementTests.t.sol
@@ -522,6 +522,9 @@ contract SettlementTests is TestUtils {
         uint256 attackerBalanceBefore = testLocalLens.getUnlockedBalances(attacker, address(inputToken));
         uint256 offererLockedBefore = testLocalLens.getLockedBalances(userA, address(inputToken));
 
+        vm.expectEmit(true, false, false, false, address(testLocalAori));
+        emit IAori.SettleFailed(orderId);
+
         vm.chainId(localEid);
         vm.prank(address(endpoints[localEid]));
         testLocalAori.lzReceive(
@@ -602,6 +605,9 @@ contract SettlementTests is TestUtils {
             uint16(1),
             orderId
         );
+
+        vm.expectEmit(true, false, false, false, address(testLocalAori));
+        emit IAori.SettleFailed(orderId);
 
         vm.chainId(localEid);
         vm.prank(address(endpoints[localEid]));

--- a/test/foundry/7_SettlementTests.t.sol
+++ b/test/foundry/7_SettlementTests.t.sol
@@ -492,4 +492,157 @@ contract SettlementTests is TestUtils {
         // The key thing we're testing is that the status didn't change to Settled (which would be 3)
         assertNotEq(actualStatus, uint8(OrderStatus.Settled), "Order status should not be Settled");
     }
+
+    /**
+     * @notice Test that settlement rejects a filler that doesn't match order.options.srcSolver
+     * @dev Simulates a compromised peer sending a forged settlement with an attacker address as filler.
+     *      When srcSolver is set, only that address should receive settled funds.
+     */
+    function testSettleRejectsMismatchedSrcSolver() public {
+        // Create an order with a specific srcSolver set to the legitimate solver
+        Order memory order = createValidOrder();
+        order.options.srcSolver = solver;
+
+        bytes memory signature = signOrderWithContract(order, userAPrivKey, address(testLocalAori));
+        bytes32 orderId = keccak256(abi.encode(order));
+
+        // Deposit the order
+        vm.prank(userA);
+        inputToken.approve(address(testLocalAori), order.inputAmount);
+
+        vm.prank(solver);
+        testLocalAori.deposit(order, signature);
+
+        // Verify order is active
+        assertEq(uint8(testLocalAori.orderStatus(orderId)), uint8(OrderStatus.Active));
+
+        // Simulate a compromised peer sending a forged settlement with an attacker as filler
+        address attacker = address(0xDEAD);
+        bytes memory forgedPayload = abi.encodePacked(
+            uint8(0),       // settlement message type
+            attacker,       // attacker's address as filler
+            uint16(1),      // fill count
+            orderId         // legitimate order
+        );
+
+        // Record balances before
+        uint256 attackerBalanceBefore = testLocalLens.getUnlockedBalances(attacker, address(inputToken));
+        uint256 offererLockedBefore = testLocalLens.getLockedBalances(userA, address(inputToken));
+
+        // Deliver the forged settlement via lzReceive
+        vm.chainId(localEid);
+        vm.prank(address(endpoints[localEid]));
+        testLocalAori.lzReceive(
+            Origin(remoteEid, bytes32(uint256(uint160(address(testRemoteAori)))), 1),
+            keccak256("forged-guid"),
+            forgedPayload,
+            address(0),
+            bytes("")
+        );
+
+        // Attacker should NOT have received any funds
+        uint256 attackerBalanceAfter = testLocalLens.getUnlockedBalances(attacker, address(inputToken));
+        assertEq(attackerBalanceBefore, attackerBalanceAfter, "Attacker should not receive funds when srcSolver is set");
+
+        // Offerer's locked balance should be unchanged (order not settled)
+        uint256 offererLockedAfter = testLocalLens.getLockedBalances(userA, address(inputToken));
+        assertEq(offererLockedBefore, offererLockedAfter, "Offerer locked balance should be unchanged");
+
+        // Order should still be Active, not Settled
+        assertEq(uint8(testLocalAori.orderStatus(orderId)), uint8(OrderStatus.Active), "Order should remain Active");
+    }
+
+    /**
+     * @notice Test that settlement succeeds when filler matches srcSolver
+     * @dev Ensures the srcSolver validation doesn't break legitimate settlements
+     */
+    function testSettleSucceedsWithMatchingSrcSolver() public {
+        // Create an order with srcSolver set to the legitimate solver
+        Order memory order = createValidOrder();
+        order.options.srcSolver = solver;
+
+        bytes memory signature = signOrderWithContract(order, userAPrivKey, address(testLocalAori));
+        bytes32 orderId = keccak256(abi.encode(order));
+
+        // Deposit the order
+        vm.prank(userA);
+        inputToken.approve(address(testLocalAori), order.inputAmount);
+
+        vm.prank(solver);
+        testLocalAori.deposit(order, signature);
+
+        assertEq(uint8(testLocalAori.orderStatus(orderId)), uint8(OrderStatus.Active));
+
+        // Send legitimate settlement with solver as filler (matches srcSolver)
+        bytes memory legitimatePayload = abi.encodePacked(
+            uint8(0),       // settlement message type
+            solver,         // legitimate solver as filler
+            uint16(1),      // fill count
+            orderId         // order
+        );
+
+        vm.chainId(localEid);
+        vm.prank(address(endpoints[localEid]));
+        testLocalAori.lzReceive(
+            Origin(remoteEid, bytes32(uint256(uint160(address(testRemoteAori)))), 1),
+            keccak256("legit-guid"),
+            legitimatePayload,
+            address(0),
+            bytes("")
+        );
+
+        // Order should be settled
+        assertEq(uint8(testLocalAori.orderStatus(orderId)), uint8(OrderStatus.Settled), "Order should be settled");
+
+        // Solver should have received unlocked balance
+        uint256 solverBalance = testLocalLens.getUnlockedBalances(solver, address(inputToken));
+        assertGt(solverBalance, 0, "Solver should have received funds");
+    }
+
+    /**
+     * @notice Test that settlement with srcSolver=address(0) allows any filler (backwards compatible)
+     */
+    function testSettleAllowsAnyFillerWhenSrcSolverUnset() public {
+        // Create order with default options (srcSolver = address(0))
+        Order memory order = createValidOrder();
+        // srcSolver is already address(0) from defaultOrderOptions()
+
+        bytes memory signature = signOrderWithContract(order, userAPrivKey, address(testLocalAori));
+        bytes32 orderId = keccak256(abi.encode(order));
+
+        // Deposit
+        vm.prank(userA);
+        inputToken.approve(address(testLocalAori), order.inputAmount);
+
+        vm.prank(solver);
+        testLocalAori.deposit(order, signature);
+
+        assertEq(uint8(testLocalAori.orderStatus(orderId)), uint8(OrderStatus.Active));
+
+        // Settle with a different address as filler — should succeed when srcSolver is unset
+        address anotherSolver = address(0xBEEF);
+        bytes memory payload = abi.encodePacked(
+            uint8(0),
+            anotherSolver,
+            uint16(1),
+            orderId
+        );
+
+        vm.chainId(localEid);
+        vm.prank(address(endpoints[localEid]));
+        testLocalAori.lzReceive(
+            Origin(remoteEid, bytes32(uint256(uint160(address(testRemoteAori)))), 1),
+            keccak256("any-filler-guid"),
+            payload,
+            address(0),
+            bytes("")
+        );
+
+        // Order should be settled (srcSolver=0 means any filler allowed)
+        assertEq(uint8(testLocalAori.orderStatus(orderId)), uint8(OrderStatus.Settled), "Order should be settled with any filler");
+
+        // The other solver should have received funds
+        uint256 otherSolverBalance = testLocalLens.getUnlockedBalances(anotherSolver, address(inputToken));
+        assertGt(otherSolverBalance, 0, "Any filler should receive funds when srcSolver is unset");
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `isAllowedSolver[filler]` validation in `AoriSettleLib._settleOrder` — rejects settlement if the filler address is not a whitelisted solver on the source chain
- Mitigates compromised-peer attack vector where a forged settlement message specifies an attacker address as `filler` to steal locked user funds (same class as Kelp DAO rsETH exploit)
- Soft-fails (emits `SettleFailed`, skips order) to avoid blocking batch settlements
- Strictly stronger than srcSolver-only validation: protects **all** orders, not just those with `srcSolver` set

## Details

The `filler` address in a cross-chain settlement payload was previously trusted without verification on the source chain. A compromised LayerZero peer could forge a settlement message with an attacker address as filler, crediting the attacker with locked user funds.

This fix adds an `isAllowedSolver` check so only protocol-whitelisted solvers can receive settlement credits. A full mitigation (filler co-signature) is under design.

## Test plan

- [x] `testSettleRejectsNonWhitelistedFiller` — forged filler (non-whitelisted attacker address) is rejected, `SettleFailed` emitted
- [x] `testSettleSucceedsWithWhitelistedFiller` — legitimate whitelisted solver receives funds
- [x] `testSettleRejectsRemovedSolver` — solver removed from whitelist after deposit cannot settle, `SettleFailed` emitted
- [x] All existing settlement tests pass (no regressions)